### PR TITLE
update CFT scripts with TAP 1.3

### DIFF
--- a/templates/aws-tap-entrypoint-existing-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-existing-vpc.template.yaml
@@ -75,9 +75,9 @@ Metadata:
           - QSS3KeyPrefix
     ParameterLabels:
       AcceptEULAs:
-        default: Have all applicable VMware Tanzu Network EULAs been accepted?
+        default: Have you read and accepted all applicable VMware Tanzu Network EULAs?
       AcceptCEIP:
-        default: Have you read and accept the VMware CEIP policy?
+        default: Have you already read and accepted the VMware CEIP policy?
       KeyPairName:
         default: EC2 key pair name
       VpcId:
@@ -204,13 +204,14 @@ Parameters:
     ConstraintDescription: >-
       Minimum length of 1. Maximum length of 100. Must start with a letter or
       number.
+    Default: cluster-eks-tap
   KubernetesVersion:
     Type: String
     Description: >-
       Version of Kubernetes control plane to deploy. The selected version must
       be supported the selected TAP version (TAPVersion). For more information,
       refer to Kubernetes cluster requirements
-      (https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.2/tap/GUID-prerequisites.html#kubernetes-cluster-requirements-3).
+      (https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.3/tap/GUID-prerequisites.html#kubernetes-cluster-requirements-3).
     AllowedValues:
       - 1.22
     Default: 1.22
@@ -491,10 +492,10 @@ Parameters:
       Version of TAP to deploy. The selected version must also support the
       selected Kubernetes version (KubernetesVersion). For more information,
       refer to Kubernetes cluster requirements
-      (https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.2/tap/GUID-prerequisites.html#kubernetes-cluster-requirements-3).
+      (https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.3/tap/GUID-prerequisites.html#kubernetes-cluster-requirements-3).
     AllowedValues:
-      - 1.3.0-rc.1
-    Default: 1.3.0-rc.1
+      - 1.3.0
+    Default: 1.3.0
   SampleAppName:
     Type: String
     Description: >-
@@ -645,13 +646,15 @@ Mappings:
     '1.22':
       AwsKubectlVersion: 1.23.7/2022-06-29
   TAPVersion:
-    1.3.0-rc.1:
-      ClusterEssentialsBundleVersion: 1.2.0
+    1.3.0:
+      ClusterEssentialsBundleVersion: 1.3.0
   ClusterEssentialsBundle:
     1.1.0:
       FileHash: sha256:ab0a3539da241a6ea59c75c0743e9058511d7c56312ea3906178ec0f3491f51d
     1.2.0:
       FileHash: sha256:e00f33b92d418f49b1af79f42cb13d6765f1c8c731f4528dfff8343af042dc3e
+    1.3.0:
+      FileHash: sha256:54bf611711923dccd7c7f10603c846782b90644d48f1cb570b43a082d18e23b9
   SampleAppProperties:
     Namespace:
       Name: tap-workload
@@ -1460,6 +1463,7 @@ Resources:
             aws s3 cp --no-progress "${QSS3BucketPath}/src/resources/git-ssh-basic-auth.yaml" ./git-ssh-basic-auth.yaml
             aws s3 cp --no-progress "${QSS3BucketPath}/src/resources/pipeline.yaml" ./pipeline.yaml
             aws s3 cp --no-progress "${QSS3BucketPath}/src/resources/scan-policy.yaml" ./scan-policy.yaml
+            aws s3 cp --no-progress "${QSS3BucketPath}/src/resources/metadata-store-ready-only.yaml" ./metadata-store-ready-only.yaml
             cat <<EOF > ./workload-aws.yaml
             ${SampleAppConfig}
             EOF
@@ -1675,12 +1679,12 @@ Rules:
           You must acknowledge that you have read and accept the VMware
           Customer Experience Improvement Program (CEIP) policy before you can
           proceed with the installation.
-  TAP1.2Interop:
-    RuleCondition: !Contains [[1.3.0-rc.1], !Ref TAPVersion]
+  TAPInterop:
+    RuleCondition: !Contains [[1.3.0], !Ref TAPVersion]
     Assertions:
       # The values below require quotes to force string comparison.
       - Assert: !Contains [['1.22', '1.23', '1.24'], !Ref KubernetesVersion]
         AssertDescription: >-
           The VMware Tanzu Application Platform version selection is
           incompatible with the Kubernetes version selection (reference:
-          https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.1/tap/GUID-prerequisites.html#kubernetes-cluster-requirements-3).
+          https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.3/tap/GUID-prerequisites.html#kubernetes-cluster-requirements-3).

--- a/templates/aws-tap-entrypoint-new-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-new-vpc.template.yaml
@@ -79,9 +79,9 @@ Metadata:
           - QSS3KeyPrefix
     ParameterLabels:
       AcceptEULAs:
-        default: Have all applicable VMware Tanzu Network EULAs been accepted?
+        default: Have you read and accepted all applicable VMware Tanzu Network EULAs?
       AcceptCEIP:
-        default: Have you read and accept the VMware CEIP policy?
+        default: Have you already read and accepted the VMware CEIP policy?
       AvailabilityZones:
         default: Availability Zones
       NumberOfAZs:
@@ -254,13 +254,14 @@ Parameters:
     ConstraintDescription: >-
       Minimum length of 1. Maximum length of 100. Must start with a letter or
       number.
+    Default: cluster-eks-tap
   KubernetesVersion:
     Type: String
     Description: >-
       Version of Kubernetes control plane to deploy. The selected version must
       be supported the selected TAP version (TAPVersion). For more information,
       refer to Kubernetes cluster requirements
-      (https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.2/tap/GUID-prerequisites.html#kubernetes-cluster-requirements-3).
+      (https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.3/tap/GUID-prerequisites.html#kubernetes-cluster-requirements-3).
     AllowedValues:
       - 1.22
     Default: 1.22
@@ -541,10 +542,10 @@ Parameters:
       Version of TAP to deploy. The selected version must also support the
       selected Kubernetes version (KubernetesVersion). For more information,
       refer to Kubernetes cluster requirements
-      (https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.2/tap/GUID-prerequisites.html#kubernetes-cluster-requirements-3).
+      (https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.3/tap/GUID-prerequisites.html#kubernetes-cluster-requirements-3).
     AllowedValues:
-      - 1.3.0-rc.1
-    Default: 1.3.0-rc.1
+      - 1.3.0
+    Default: 1.3.0
   SampleAppName:
     Type: String
     Description: >-
@@ -728,15 +729,15 @@ Rules:
     Assertions:
       - Assert: !Equals [!Ref AcceptCEIP, 'Yes']
         AssertDescription: >-
-          You must acknowledge that you have read and accept the VMware
+          You must acknowledge that you have read and accepted the VMware
           Customer Experience Improvement Program (CEIP) policy before you can
           proceed with the installation.
-  TAP1.2Interop:
-    RuleCondition: !Contains [[1.3.0-rc.1], !Ref TAPVersion]
+  TAPInterop:
+    RuleCondition: !Contains [[1.3.0], !Ref TAPVersion]
     Assertions:
       # The values below require quotes to force string comparison.
       - Assert: !Contains [['1.22', '1.23', '1.24'], !Ref KubernetesVersion]
         AssertDescription: >-
           The VMware Tanzu Application Platform version selection is
           incompatible with the Kubernetes version selection (reference:
-          https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.1/tap/GUID-prerequisites.html#kubernetes-cluster-requirements-3).
+          https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.3/tap/GUID-prerequisites.html#kubernetes-cluster-requirements-3).


### PR DESCRIPTION
- Update TAP install scripts for TAP new release 1.3.0
- Update AcceptEULAs & AcceptCEIP ParameterLabels Descriptions.
- Add default value for EKS cluster name
- Update TAP 1.3 docs references
