### PR TITLE
Fix regression for single cluster deployments

### DIFF
--- a/templates/aws-tap-entrypoint-existing-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-existing-vpc.template.yaml
@@ -1043,7 +1043,7 @@ Resources:
         NodeInstanceFamily: Standard
         NodeGroupType: Managed
         NodeGroupOS: Amazon Linux 2
-        EKSClusterName: !Join ['', [!Ref EKSClusterName, "-single" ]]
+        EKSClusterName: !Ref EKSClusterName
         ClusterAutoScaler: Enabled
         MonitoringStack: None
         ALBIngressController: Enabled


### PR DESCRIPTION
Deployment succeeds with single cluster arch (`taskcat test run`).
Multi cluster arch not tested.