### PR TITLE
Add pipeline to build CI container images

### DIFF
--- a/ci/images/docker-image/Dockerfile
+++ b/ci/images/docker-image/Dockerfile
@@ -1,0 +1,18 @@
+ARG BASE=devtools-docker.artifactory.eng.vmware.com/vmware/runway/resourcetypes/docker-in-nimbus-task:0.13.1
+FROM "${BASE}"
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get -qy update \
+        && apt-get -qy install -o APT::Install-Suggests=0 -o APT::Install-Recommends=0 \
+            curl \
+            git \
+            less \
+            python3-pip \
+        && pip3 --no-cache-dir install --upgrade \
+            pip \
+            setuptools \
+        && python3 -m pip --no-cache-dir install \
+            awscli \
+            taskcat \
+        && rm -rf /var/lib/apt/lists/*

--- a/ci/images/pipeline.vars.yml
+++ b/ci/images/pipeline.vars.yml
@@ -1,0 +1,17 @@
+repo:
+  uri: git@github.com:hoegaarden/quickstart-vmware-tanzu-application-platform
+  branch: TAPPC-131_ci-build-images
+  ro-key: ((ci/repo-keys/github/hoegaarden/quickstart-vmware-tanzu-application-platform.ro))
+
+dockerhub-proxy: harbor-repo.vmware.com/dockerhub-proxy-cache
+
+#! new versions can be found at:
+#! https://artifactory.eng.vmware.com/ui/repos/tree/General/devtools-docker/vmware/runway/resourcetypes/docker-in-nimbus-task
+docker-in-nimbus:
+  repo: devtools-docker.artifactory.eng.vmware.com/vmware/runway/resourcetypes/docker-in-nimbus-task
+  tag: 0.13.1
+
+tappc-registry:
+  url: tappc-docker-local.artifactory.eng.vmware.com
+  username: ((ci/registry/tappc.username))
+  password: ((ci/registry/tappc.password))

--- a/ci/images/pipeline.vars.yml
+++ b/ci/images/pipeline.vars.yml
@@ -1,7 +1,6 @@
 repo:
-  uri: git@github.com:hoegaarden/quickstart-vmware-tanzu-application-platform
+  url: https://github.com/hoegaarden/quickstart-vmware-tanzu-application-platform
   branch: TAPPC-131_ci-build-images
-  ro-key: ((ci/repo-keys/github/hoegaarden/quickstart-vmware-tanzu-application-platform.ro))
 
 dockerhub-proxy: harbor-repo.vmware.com/dockerhub-proxy-cache
 

--- a/ci/images/pipeline.yml
+++ b/ci/images/pipeline.yml
@@ -1,0 +1,38 @@
+resources:
+- name: ci-repo
+  type: git
+  source:
+    uri: ((repo.uri))
+    branch: ((repo.branch))
+    private_key: ((repo.ro-key))
+    paths:
+    - ci/
+- name: docker-image
+  type: registry-image
+  icon: docker
+  source:
+    repository: ((tappc-registry.url))/ci/docker-image
+    username: ((tappc-registry.username))
+    password: ((tappc-registry.password))
+    tag: latest
+
+jobs:
+- name: build-docker-image
+  plan:
+  - get: ci-repo
+    params:
+      submodules: none
+  - task: build
+    file: ci-repo/ci/tasks/build-image/task.yml
+    vars:
+      repo: ((docker-in-nimbus.repo))
+      tag: ((docker-in-nimbus.tag))
+    input_mapping:
+      input: ci-repo
+    params:
+      NIMBUS_USER: ((ci/nimbus.user))
+      BUILD_ARG_BASE: ((docker-in-nimbus.repo)):((docker-in-nimbus.tag))
+      CONTEXT: input/ci/images/docker-image
+  - put: docker-image
+    params:
+      image: image/image.tar

--- a/ci/images/pipeline.yml
+++ b/ci/images/pipeline.yml
@@ -1,6 +1,8 @@
 resources:
 - name: ci-repo
   type: git
+  check_every: 1m
+  icon: github
   source:
     uri: ((repo.uri))
     branch: ((repo.branch))

--- a/ci/images/pipeline.yml
+++ b/ci/images/pipeline.yml
@@ -17,6 +17,17 @@ resources:
     tag: latest
 
 jobs:
+- name: set-pipeline
+  plan:
+  - get: ci-repo
+    params:
+      submodules: none
+    trigger: true
+  - set_pipeline: self
+    file: ci-repo/ci/images/pipeline.yml
+    var_files:
+    - ci-repo/ci/images/pipeline.vars.yml
+
 - name: build-docker-image
   plan:
   - get: ci-repo

--- a/ci/images/pipeline.yml
+++ b/ci/images/pipeline.yml
@@ -33,6 +33,9 @@ jobs:
   - get: ci-repo
     params:
       submodules: none
+    passed:
+    - set-pipeline
+    trigger: true
   - task: build
     file: ci-repo/ci/tasks/build-image/task.yml
     vars:

--- a/ci/images/pipeline.yml
+++ b/ci/images/pipeline.yml
@@ -4,9 +4,8 @@ resources:
   check_every: 1m
   icon: github
   source:
-    uri: ((repo.uri))
+    uri: ((repo.url))
     branch: ((repo.branch))
-    private_key: ((repo.ro-key))
     paths:
     - ci/
 - name: docker-image

--- a/ci/images/set-pipeline.sh
+++ b/ci/images/set-pipeline.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+set -o pipefail
+
+readonly DIR="$( cd "$(dirname "${BASH_SOURCE[0]}")" && pwd )"
+
+main() {
+    # the default pipeline name is the basename of this directory
+    local defaultPipelineName="${DIR##*/}"
+
+    fly --target "${FLY_TARGET:-tappc}" \
+        set-pipeline \
+            --pipeline "${PIPELINE_NAME:-${defaultPipelineName}}" \
+            --config "${DIR}/pipeline.yml" \
+            --load-vars-from "${DIR}/pipeline.vars.yml" \
+            --check-creds
+}
+
+main "$@"

--- a/ci/tasks/build-image/task.yml
+++ b/ci/tasks/build-image/task.yml
@@ -1,0 +1,17 @@
+#! https://gitlab.eng.vmware.com/devtools/runway/concourse/resourcetypes/official/docker-in-nimbus-task/
+---
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    repository: ((repo)) #! e.g. devtools-docker.artifactory.eng.vmware.com/vmware/runway/resourcetypes/docker-in-nimbus-task
+    tag: ((tag)) #! e.g. 0.13.0
+
+inputs:
+- name: input
+
+outputs:
+- name: image
+
+run:
+  path: build


### PR DESCRIPTION
Get infra in place and create pipeline to build container images, to be used in concourse.

To build those images, we use the `docker-in-nimbus` task, provided by the runway team. This spins up an ephemeral nimbus VM, runs `dockerd` there and wires it into the task container. Therefore we don't need to go the nested & priv'ed container route.

The first image we build here is an image, which
- has taskcat
- can run docker
- some other random tools (curl, yq, ...)

This image is based on the very same `docker-in-nimbus` task, so that we can run `dockerd` here too, to be able to package up the lambdas.

Note: right now, the config of the pipeline points to my fork & a specific branch. Once we are happy with the approach, I can switch that over just before the merge.