### PR TITLE
Publish to a public bucket once the main pipeline goes green

### DIFF
--- a/ci/qs-test/pipeline.vars.yml
+++ b/ci/qs-test/pipeline.vars.yml
@@ -9,3 +9,10 @@ tappc-registry:
   url: tappc-docker-local.artifactory.eng.vmware.com
   username: ((ci/registry/tappc.username))
   password: ((ci/registry/tappc.password))
+
+publish-bucket:
+  name: tcat-9d0156f41d3b503b8360120b8214b6f1-us-east-1
+  prefix: public/main/
+
+ci-bucket:
+  name-without-region: tcat-9d0156f41d3b503b8360120b8214b6f1

--- a/ci/qs-test/pipeline.yml
+++ b/ci/qs-test/pipeline.yml
@@ -50,6 +50,13 @@ resources:
     #! TODO: get a proper PAT
     access_token: ((ci/repo-keys/github/hoegaarden/quickstart-vmware-tanzu-application-platform.pat))
     disable_forks: false
+- name: daily-run
+  type: time
+  source:
+    location: UTC
+    start: 05:00 AM
+    stop: 06:00 AM
+    days: [ Monday, Tuesday, Wednesday, Thursday, Friday ]
 
 alerting:
   onJobs: &alertingOnJobs
@@ -89,6 +96,8 @@ jobs:
   serial: true
   plan:
   - in_parallel:
+    - get: dialy-run
+      trigger: true
     - get: ci-repo
       params:
         submodules: none

--- a/ci/qs-test/pipeline.yml
+++ b/ci/qs-test/pipeline.yml
@@ -115,7 +115,7 @@ jobs:
         VAR_tanzunet_password: ((ci/tanzunet.password))
         VAR_tanzunet_refreshToken: ((ci/tanzunet.refreshToken))
         VAR_keypairName: ((ci/qs-test/keypair.name))
-        VAR_bucket: tcat-9d0156f41d3b503b8360120b8214b6f1
+        VAR_bucket: ((ci-bucket.name-without-region))
         VAR_domain: thingamaji.ga
 
   - task: taskcat-prepare-bucket
@@ -192,7 +192,7 @@ jobs:
   - task: publish-bucket
     files: ci-repo/ci/tasks/taskcat-bucket-sync/task.yml
     params:
-      DESTINATION_BUCKET: tcat-9d0156f41d3b503b8360120b8214b6f1-us-east-1/public/main/
+      DESTINATION_BUCKET: ((publish-bucket.name))/((publish-bucket.prefix))
 #! ---< main ----
 
 #! ---> PR stuff ----

--- a/ci/qs-test/pipeline.yml
+++ b/ci/qs-test/pipeline.yml
@@ -173,6 +173,26 @@ jobs:
     params:
       TEST_NAME: multi
     ensure: *postTest
+
+- name: publish-bucket
+  << : *alertingOnJobs
+  plan:
+  - in_parallel:
+    - get: ci-repo
+      params:
+        submodules: none
+      trigger: true
+      passed: [ test-single, test-multi ]
+    - get: repo
+      params:
+        submodules: none
+      trigger: true
+      passed: [ test-single, test-multi ]
+  - *setup
+  - task: publish-bucket
+    files: ci-repo/ci/tasks/taskcat-bucket-sync/task.yml
+    params:
+      DESTINATION_BUCKET: tcat-9d0156f41d3b503b8360120b8214b6f1-us-east-1/public/main/
 #! ---< main ----
 
 #! ---> PR stuff ----

--- a/ci/tasks/taskcat-bucket-sync/task.sh
+++ b/ci/tasks/taskcat-bucket-sync/task.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+set -o pipefail
+
+# shellcheck disable=SC1091
+source creds/env.inc.sh
+
+ensureSingleTrailingSlash() {
+  sed 's,/*$,/,g'
+}
+
+main() {
+  local region srcBucket
+  local destBucket destBucketName destBucketPrefix
+  local url
+
+  region="$(
+    yq -r '.project.parameters.QSS3BucketRegion' taskcat-config/taskcat.yml
+  )"
+  srcBucket="$(
+    yq -r '.project.parameters | "\(.QSS3BucketName)/\(.QSS3KeyPrefix)"' taskcat-config/taskcat.yml
+  )"
+
+  srcBucket="$( ensureSingleTrailingSlash <<< "$srcBucket" )"
+  destBucket="$( ensureSingleTrailingSlash <<< "${DESTINATION_BUCKET?}" )"
+  destBucketName="${destBucket%%/*}"
+  destBucketPrefix="${destBucket#*/}"
+
+  aws s3 sync "s3://${srcBucket}" "s3://${destBucket}"
+
+  echo
+  echo "Published to 's3://${destBucket}'"
+  echo
+
+  url=(
+    "https://${region}.console.aws.amazon.com/cloudformation/home?region=${region}#/stacks/create"
+    "?stackName=vmware-tap-internal"
+    "&templateURL=https://${destBucketName}.s3.${region}.amazonaws.com/${destBucketPrefix}templates/aws-tap-entrypoint-new-vpc.template.yaml"
+    "&param_QSS3BucketName=${destBucketName}"
+    "&param_QSS3BucketRegion=${region}"
+    "&param_QSS3KeyPrefix=${destBucketPrefix}"
+  )
+
+  echo "Stack can be deployed via:"
+
+  echo
+  printf '%s' '  ' "${url[@]}" $'\n'
+  echo
+
+  echo "    QSS3BucketName:   ${destBucketName}"
+  echo "    QSS3KeyPrefix:    ${destBucketPrefix}"
+  echo "    QSS3BucketRegion: ${region}"
+}
+
+main "$@"

--- a/ci/tasks/taskcat-bucket-sync/task.yml
+++ b/ci/tasks/taskcat-bucket-sync/task.yml
@@ -1,0 +1,15 @@
+---
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    repository: tappc-docker-local.artifactory.eng.vmware.com/ci/docker-image
+    tag: latest
+inputs:
+- name: taskcat-config
+- name: creds
+- name: ci-repo
+run:
+  path: ci-repo/ci/tasks/taskcat-bucket-sync/task.sh
+params:
+  DESTINATION_BUCKET: someBucket/someDir


### PR DESCRIPTION
- For now we'll use the same bucket, but publish to a different prefix `/public/`
- This prefix allows publich object get via bucket policy
- According to [the docs], we can also pass in parameters to the stack via URL, which I try to do ... but for some reason this does not work for me :shrug: 


[the docs]: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-console-create-stacks-quick-create-links.html