### PR TITLE
Update some pipeline creds

### DIFF
--- a/ci/images/pipeline.vars.yml
+++ b/ci/images/pipeline.vars.yml
@@ -13,5 +13,5 @@ docker-in-nimbus:
 
 tappc-registry:
   url: tappc-docker-local.artifactory.eng.vmware.com
-  username: ((ci/registry/tappc.username))
-  password: ((ci/registry/tappc.password))
+  username: ((ci/serviceaccount/tappc-ci.username))
+  password: ((ci/serviceaccount/tappc-ci.password))

--- a/ci/qs-test/pipeline.vars.yml
+++ b/ci/qs-test/pipeline.vars.yml
@@ -9,8 +9,8 @@ ci-repo:
 
 tappc-registry:
   url: tappc-docker-local.artifactory.eng.vmware.com
-  username: ((ci/registry/tappc.username))
-  password: ((ci/registry/tappc.password))
+  username: ((ci/serviceaccount/tappc-ci.username))
+  password: ((ci/serviceaccount/tappc-ci.password))
 
 publish-bucket:
   name: tcat-9d0156f41d3b503b8360120b8214b6f1-us-east-1

--- a/ci/qs-test/pipeline.yml
+++ b/ci/qs-test/pipeline.yml
@@ -280,6 +280,14 @@ jobs:
       params:
         submodules: none
       passed: [ set-pipeline ]
-  - *getCloudGateCreds
-  - task: stacks-housekeeping
-    file: ci-repo/ci/tasks/aws-housekeeping/stacks.yml
+  - in_parallel:
+    - do:
+      - *getCloudGateCreds
+      - task: stacks-housekeeping
+        file: ci-repo/ci/tasks/aws-housekeeping/stacks.yml
+    - task: check-pr-resource-token
+      file: ci-repo/ci/tasks/github-token-expiry/task.yml
+      params:
+        SECRET_PATH: ci/pr-resource
+        EXPIRATION_DATE: ((ci/pr-resource.expiration))
+        MIN_DAYS_LEFT: 30

--- a/ci/qs-test/pipeline.yml
+++ b/ci/qs-test/pipeline.yml
@@ -47,8 +47,7 @@ resources:
   type: pull-request
   source:
     repository: ((repo.slug))
-    #! TODO: get a proper PAT
-    access_token: ((ci/repo-keys/github/hoegaarden/quickstart-vmware-tanzu-application-platform.pat))
+    access_token: ((ci/pr-resource.token))
     disable_forks: false
 - name: daily-run
   type: time

--- a/ci/tasks/github-token-expiry/task.py
+++ b/ci/tasks/github-token-expiry/task.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+
+from datetime import date, datetime
+import sys
+import os
+
+expDate = datetime.strptime(os.getenv('EXPIRATION_DATE'), "%Y-%m-%d")
+delta = expDate.date() - date.today()
+secretPath = os.getenv('SECRET_PATH')
+
+# token still valid, nothing to do except exiting gracefully
+if delta.days > int(os.getenv('MIN_DAYS_LEFT')):
+  print(f"Token at '{secretPath}' still valid for {delta.days} days")
+  sys.exit(0)
+
+print(f"""
+⚠️  The GitHub Personal Access Token is about to expire in {delta.days} days! ⚠️
+
+Please:
+- refresh or create a new token (with 'repo' scope)
+- update the 'token' field in '{secretPath}' with the new token (e.g. 'ghp_A3K......')
+- update the 'expiration' field in '{secretPath}' with the expiration date (in ISO 8601 format, i.e. run 'date -I')
+""")
+sys.exit(1)

--- a/ci/tasks/github-token-expiry/task.yml
+++ b/ci/tasks/github-token-expiry/task.yml
@@ -1,0 +1,16 @@
+---
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    repository: tappc-docker-local.artifactory.eng.vmware.com/ci/docker-image
+    tag: latest
+inputs:
+- name: ci-repo
+run:
+  path: ci-repo/ci/tasks/github-token-expiry/task.py
+params:
+  PYTHONIOENCODING: utf-8
+  SECRET_PATH: some/path/in/vault
+  EXPIRATION_DATE: ((some/path/in/vault.expiration))
+  MIN_DAYS_LEFT: 12


### PR DESCRIPTION
The service account has been created and has the correct permissions. The secret is already in vault. Thus we should be able to just switch over.
Once we ensured we are able to push with that serviceaccount from the pipeline we can remove the `ci/registry/tappc` from vault.

Also I added a proper PAT for the concourse-pr-resource and a quick small helper, which runs as part of the housekeeping job, which would notify us when the token expires,