### PR TITLE
Fix stack create URL

### DIFF
--- a/ci/tasks/taskcat-bucket-sync/task.sh
+++ b/ci/tasks/taskcat-bucket-sync/task.sh
@@ -11,10 +11,14 @@ ensureSingleTrailingSlash() {
   sed 's,/*$,/,g'
 }
 
+uriEncode() {
+  jq -rn --arg data "$1" '$data | @uri'
+}
+
 main() {
   local region srcBucket
   local destBucket destBucketName destBucketPrefix
-  local url
+  local urlParts urlTemplate stackName
 
   region="$(
     yq -r '.project.parameters.QSS3BucketRegion' taskcat-config/taskcat.yml
@@ -34,19 +38,22 @@ main() {
   echo "Published to 's3://${destBucket}'"
   echo
 
-  url=(
-    "https://${region}.console.aws.amazon.com/cloudformation/home?region=${region}#/stacks/create"
-    "?stackName=vmware-tap-internal"
-    "&templateURL=https://${destBucketName}.s3.${region}.amazonaws.com/${destBucketPrefix}templates/aws-tap-entrypoint-new-vpc.template.yaml"
-    "&param_QSS3BucketName=${destBucketName}"
-    "&param_QSS3BucketRegion=${region}"
-    "&param_QSS3KeyPrefix=${destBucketPrefix}"
+  stackName='tap-internal'
+  urlTemplate="https://${destBucketName}.s3.amazonaws.com/${destBucketPrefix}templates/aws-tap-entrypoint-new-vpc.template.yaml"
+  urlParts=(
+    "https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate"
+    "?templateURL=$( uriEncode "$urlTemplate" )"
+    "&stackName=$( uriEncode "$stackName" )"
+    "&param_EKSClusterName=$( uriEncode "$stackName" )"
+    "&param_QSS3BucketName=$( uriEncode "$destBucketName" )"
+    "&param_QSS3BucketRegion=$( uriEncode "$region" )"
+    "&param_QSS3KeyPrefix=$( uriEncode "$destBucketPrefix" )"
   )
 
   echo "Stack can be deployed via:"
 
   echo
-  printf '%s' '  ' "${url[@]}" $'\n'
+  printf '%s' '  ' "${urlParts[@]}" $'\n'
   echo
 
   echo "    QSS3BucketName:   ${destBucketName}"


### PR DESCRIPTION
- Using `/stacks/quickcreate` instead of `/stacks/create`, which allows us to pass on parameters; we do that to pass on the correct bucket coordinates
- properly URI-escape parameters