### PR TITLE
Publish the QS to a different bucket

### DIFF
--- a/ci/qs-test/pipeline.vars.yml
+++ b/ci/qs-test/pipeline.vars.yml
@@ -15,7 +15,7 @@ tappc-registry:
   password: ((ci/serviceaccount/tappc-ci.password))
 
 publish-bucket:
-  name: tcat-9d0156f41d3b503b8360120b8214b6f1-us-east-1
+  name: tap-quickstart
   prefix: public/main/
 
 ci-bucket:


### PR DESCRIPTION
The bucket has already been set up (manually) in the CI account.