### PR TITLE
[ci skip] Don't run the CI pipeline if only `/ci/...` changes

### DIFF
--- a/ci/qs-test/pipeline.yml
+++ b/ci/qs-test/pipeline.yml
@@ -58,6 +58,8 @@ resources:
     repository: ((repo.slug))
     access_token: ((ci/pr-resource.token))
     disable_forks: false
+    ignore_paths:
+    - ci/
 - name: daily-run
   type: time
   source:


### PR DESCRIPTION
This might have implications on TAPPC-148, but for now let's not run the pipeline if there are no real prod code changes.