### PR TITLE
Only consider pull requests against `main`

### DIFF
--- a/ci/qs-test/pipeline.yml
+++ b/ci/qs-test/pipeline.yml
@@ -58,6 +58,7 @@ resources:
     repository: ((repo.slug))
     access_token: ((ci/pr-resource.token))
     disable_forks: false
+    base_bracnch: main
     ignore_paths:
     - ci/
 - name: daily-run


### PR DESCRIPTION
So we don't trigger on PRs against e.g. `doc-edits` and other branches.