### PR TITLE
Make python happy in the container

### DIFF
--- a/ci/images/docker-image/Dockerfile
+++ b/ci/images/docker-image/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE=devtools-docker.artifactory.eng.vmware.com/vmware/runway/resourcetypes/docker-in-nimbus-task:0.13.1
+ARG BASE=devtools-docker.artifactory.eng.vmware.com/vmware/runway/resourcetypes/docker-in-nimbus-task:0.13.4
 
 FROM ghcr.io/vmware-tanzu/carvel-docker-image AS carvel
 

--- a/ci/images/docker-image/Dockerfile
+++ b/ci/images/docker-image/Dockerfile
@@ -12,6 +12,7 @@ RUN apt-get -qy update \
             git \
             jq \
             less \
+            locales \
             pigz \
             python3-pip \
         && pip3 --no-cache-dir install --upgrade \
@@ -22,5 +23,15 @@ RUN apt-get -qy update \
             taskcat \
             yq \
         && rm -rf /var/lib/apt/lists/*
+
+ARG DEFAULT_LOCALE='en_US.UTF-8'
+
+# Needs to look something like `en_US.UTF-8 UTF-8`
+RUN echo "${DEFAULT_LOCALE} ${DEFAULT_LOCALE##*.}" > /etc/locale.gen \
+        && locale-gen
+
+ENV LC_ALL="${DEFAULT_LOCALE}"
+ENV LANG="${DEFAULT_LOCALE}"
+ENV LANGUAGE="${DEFAULT_LOCALE}"
 
 COPY --from=carvel /usr/local/bin/ytt /usr/local/bin/ytt

--- a/ci/images/pipeline.vars.yml
+++ b/ci/images/pipeline.vars.yml
@@ -9,7 +9,7 @@ dockerhub-proxy: harbor-repo.vmware.com/dockerhub-proxy-cache
 #! https://artifactory.eng.vmware.com/ui/repos/tree/General/devtools-docker/vmware/runway/resourcetypes/docker-in-nimbus-task
 docker-in-nimbus:
   repo: devtools-docker.artifactory.eng.vmware.com/vmware/runway/resourcetypes/docker-in-nimbus-task
-  tag: 0.13.3
+  tag: 0.13.4
 
 tappc-registry:
   url: tappc-docker-local.artifactory.eng.vmware.com


### PR DESCRIPTION
- Setting up locales
    - so that we can run `taskcat` (and other python things) without complaining about `[...] UnicodeEncodeError: 'ascii' codec can't encode characters [...]`
- Opportunistically also base the image on the newest upstream base layer