### PR TITLE
Signal result of tap-install-script back to the stack

### DIFF
--- a/ci/qs-test/pipeline.yml
+++ b/ci/qs-test/pipeline.yml
@@ -197,6 +197,8 @@ jobs:
       in_parallel:
       - task: print-logs
         file: ci-repo/ci/tasks/taskcat-print-logs/task.yml
+      - task: print-durations
+        file: ci-repo/ci/tasks/taskcat-print-durations/task.yml
       - task: cleanup-stack
         file: ci-repo/ci/tasks/aws-delete-stack/task.yml
 

--- a/ci/tasks/taskcat-print-durations/task.sh
+++ b/ci/tasks/taskcat-print-durations/task.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+set -o pipefail
+
+REGION="$( cat test-result/region )"
+STACK_NAME="$( cat test-result/stackName )"
+readonly STACK_NAME REGION
+
+readonly -A PHASES=(
+  # LogicalResourceId => OutputName
+  ["$STACK_NAME"]='FullStack'
+  ['PhaseCloudInit']=''
+  ['PhaseTAPInstall']=''
+  ['PhaseTAPWorkloadInstall']=''
+  ['PhaseTAPTests']=''
+)
+
+main() {
+  local logicalId outputName
+  local -a phaseTimes
+  local start end
+  local durations='{}'
+
+  local logFile="test-result/${STACK_NAME}-${REGION}-cfnlogs.txt"
+
+  for logicalId in "${!PHASES[@]}" ; do
+    outputName="${PHASES[$logicalId]}"
+    test -z "$outputName" && outputName="$logicalId"
+
+    # collect all event logs' times, sort them and push them into an array
+    # log lines look something like that:
+    # ```
+    #   [...]
+    # 2023-01-30 12:39:41.514000+00:00  CREATE_COMPLETE     AWS::CloudFormation::WaitCondition        WaitForTAPTests
+    # 2023-01-30 12:39:41.033000+00:00  CREATE_IN_PROGRESS  AWS::CloudFormation::WaitCondition        WaitForTAPTests                                   Resource creation Initiated
+    # 2023-01-30 12:39:40.786000+00:00  CREATE_IN_PROGRESS  AWS::CloudFormation::WaitCondition        WaitForTAPTests
+    #   [...]
+    # ```
+    mapfile -t phaseTimes < <(
+      awk -v phase="${logicalId}" '$5 == phase { print $1 " " $2 }' "$logFile" \
+        | sort
+    )
+
+    # convert from datetime to epoch seconds
+    start="$( date -d "${phaseTimes[0]}" '+%s' )" || {
+      echo >&2 "⚠️ Could not pull start time for '${logicalId}' from taskcat logs"
+      continue
+    }
+    end="$( date -d "${phaseTimes[-1]}" '+%s' )" || {
+      echo >&2 "⚠️ Could not pull end time for '${logicalId}' from taskcat logs"
+      continue
+    }
+
+    # add the duration, in minutes, to the durations object
+    durations="$(
+      jq \
+        --argjson pStart "${start}" \
+        --argjson pEnd "${end}" \
+        --arg phase "${outputName}" \
+        '. + { "\($phase)" : ((($pEnd - $pStart)/60)*100 | round / 100) }' \
+        <<< "$durations"
+    )"
+  done
+
+  # For now, we only print the durations of the different phases. We could also
+  # push them out somewhere if we wanted to.
+  echo >&2 '# Durations in minutes:'
+  jq . <<< "$durations"
+}
+
+main "$@"

--- a/ci/tasks/taskcat-print-durations/task.yml
+++ b/ci/tasks/taskcat-print-durations/task.yml
@@ -1,0 +1,12 @@
+---
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    repository: tappc-docker-local.artifactory.eng.vmware.com/ci/docker-image
+    tag: latest
+inputs:
+- name: test-result
+- name: ci-repo
+run:
+  path: ci-repo/ci/tasks/taskcat-print-durations/task.sh

--- a/tap-setup-scripts/src/cloud-init.sh
+++ b/tap-setup-scripts/src/cloud-init.sh
@@ -1,0 +1,221 @@
+#!/usr/bin/env bash
+
+set -ex
+
+arch=$(dpkg --print-architecture)
+user=ubuntu
+tap_dir=/home/$user/tap-setup-scripts
+uname=$(uname -m)
+set -a
+
+echo "Installing python dependencies for $user..."
+su - $user -c "mkdir -p /home/$user/.local/bin; source /home/$user/.profile; python3 -m pip install --upgrade pip setuptools wheel yq"
+echo "Updating certificate authority certificates..."
+update-ca-certificates
+echo "Installing Amazon CloudWatch agent..."
+mkdir -p /opt/aws/amazon-cloudwatch-agent/etc/
+cat <<EOF >> /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
+{
+  "metrics": {
+    "append_dimensions": {
+      "ImageId": "\${aws:ImageId}",
+      "InstanceId": "\${aws:InstanceId}",
+      "InstanceType": "\${aws:InstanceType}"
+    },
+    "metrics_collected": {
+      "mem": {
+        "measurement": [
+          "mem_used_percent"
+        ]
+      },
+      "swap": {
+        "measurement": [
+          "swap_used_percent"
+        ]
+      }
+    }
+  },
+  "logs": {
+    "logs_collected": {
+      "files": {
+        "collect_list": [
+          {
+            "file_path": "/var/log/cloud-init-output.log",
+            "log_group_name": "${TAPLogGroup}",
+            "log_stream_name": "{instance_id}_/var/log/cloud-init-output.log"
+          }
+        ]
+      }
+    }
+  }
+}
+EOF
+
+
+pushd /tmp
+aws s3 cp --no-progress "s3://amazoncloudwatch-agent-${AWS_REGION}/ubuntu/${arch}/latest/amazon-cloudwatch-agent.deb" ./amazon-cloudwatch-agent.deb
+dpkg -i ./amazon-cloudwatch-agent.deb
+popd
+/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json -s
+systemctl enable amazon-cloudwatch-agent.service
+systemctl start amazon-cloudwatch-agent.service
+systemctl status amazon-cloudwatch-agent.service
+echo "Installing kubectl..."
+pushd /tmp
+aws s3 cp --no-progress "s3://amazon-eks/${AwsKubectlVersion}/bin/linux/$arch/kubectl" ./kubectl
+aws s3 cp --no-progress "s3://amazon-eks/${AwsKubectlVersion}/bin/linux/$arch/kubectl.sha256" ./kubectl.sha256
+openssl sha1 -sha256 ./kubectl
+chmod 755 ./kubectl
+mv ./kubectl /usr/local/bin/
+kubectl completion bash > /etc/bash_completion.d/kubectl
+popd
+echo "Configuring Docker..."
+getent group docker || groupadd docker
+usermod -aG docker $user
+mkdir -p /root/.docker
+su - $user -c "mkdir -p /home/$user/.docker"
+pushd /tmp
+curl -fsSL "https://github.com/docker/docker-credential-helpers/releases/download/v${DockerCredPassVersion}/docker-credential-pass-v${DockerCredPassVersion}-$arch.tar.gz" | tar xz -C .
+mv docker-credential-pass /usr/local/bin/
+popd
+
+
+cat <<EOF > /root/.docker/config.json
+{
+  "credHelpers": {
+    "${AWSAccountId}.dkr.ecr.${AWS_REGION}.amazonaws.com": "ecr-login",
+    "public.ecr.aws": "ecr-login"
+  }
+}
+EOF
+cp /root/.docker/config.json /home/$user/.docker/
+chown $user:$user /home/$user/.docker/config.json
+echo "Configuring the SSH listening port..."
+printf "Port ${LinuxBastionSshPort}\n" > /etc/ssh/sshd_config.d/port.conf
+systemctl restart sshd.service
+systemctl status sshd.service
+echo "Downloading the VMware Tanzu Application Platform Quick Start scripts..."
+su - $user -c "mkdir -p \"$tap_dir/downloads\" \"$tap_dir/generated\" \"$tap_dir/src/inputs\" \"$tap_dir/src/resources\""
+pushd "$tap_dir/src"
+aws s3 cp --no-progress "${QSS3BucketPath}/src/tap-main.sh" ./tap-main.sh
+chmod +x ./tap-main.sh
+aws s3 cp --no-progress "${QSS3BucketPath}/src/tap-relocate.sh" ./tap-relocate.sh
+chmod +x ./tap-relocate.sh
+aws s3 cp --no-progress "${QSS3BucketPath}/src/install-tools.sh" ./install-tools.sh
+chmod +x ./install-tools.sh
+aws s3 cp --no-progress "${QSS3BucketPath}/src/functions.sh" ./functions.sh
+popd
+
+
+
+pushd "$tap_dir/src/inputs"
+aws s3 cp --no-progress "${QSS3BucketPath}/src/inputs/tap-values-build.yaml" ./tap-values-build.yaml
+aws s3 cp --no-progress "${QSS3BucketPath}/src/inputs/tap-values-run.yaml" ./tap-values-run.yaml
+aws s3 cp --no-progress "${QSS3BucketPath}/src/inputs/tap-values-iterate.yaml" ./tap-values-iterate.yaml
+aws s3 cp --no-progress "${QSS3BucketPath}/src/inputs/tap-values-view.yaml" ./tap-values-view.yaml
+aws s3 cp --no-progress "${QSS3BucketPath}/src/inputs/tap-values-single.yaml" ./tap-values-single.yaml
+echo "Logging script input parameters"
+echo ClusterArch ${ClusterArch}
+echo BuildClusterBuildServiceArn ${BuildClusterBuildServiceArn}
+echo BuildClusterWorkloadArn ${BuildClusterWorkloadArn}
+echo IterateClusterBuildServiceArn ${IterateClusterBuildServiceArn}
+echo IterateClusterWorkloadArn ${IterateClusterWorkloadArn}
+echo BuildClusterName ${BuildClusterName}
+echo RunClusterName ${RunClusterName}
+echo ViewClusterName ${ViewClusterName}
+echo IterateClusterName ${IterateClusterName}
+cat <<EOF > ./user-input-values.yaml
+#@data/values
+---
+tanzunet:
+  server: ${TanzuNetRegistryServer}
+  relocate_images: "${TanzuNetRelocateImages}"
+  secrets:
+    credentials_arn: ${TanzuNetSecretCredentials}
+cluster_essentials_bundle:
+  bundle: ${TanzuNetRegistryServer}/${ClusterEssentialsBundleRepo}
+  file_hash: ${ClusterEssentialsBundleFileHash}
+  version: ${ClusterEssentialsBundleVersion}
+tap:
+  name: tap
+  namespace: tap-install
+  repository: ${TanzuNetRegistryServer}/${TAPRepo}
+  version: ${TAPVersion}
+cluster:
+  arch: ${ClusterArch}
+  name: ${EKSClusterName}
+buildservice:
+  build_cluster_arn: ${BuildClusterBuildServiceArn}
+  iterate_cluster_arn: ${IterateClusterBuildServiceArn}
+dns:
+  domain_name: ${TAPDomainName}
+  zone_id: ${PrivateHostedZone}
+repositories:
+  tap_packages: ${TAPPackagesRepo_RepositoryUri}
+  cluster_essentials: ${TAPClusterEssentialsBundleRepo_RepositoryUri}
+  build_service: ${TAPBuildServiceRepo_RepositoryUri}
+  workload:
+    name: ${SampleAppName}
+    namespace: ${SampleAppNamespace}
+    repository: ${TAPWorkloadRepo_RepositoryUri}
+    bundle_repository: ${TAPWorkloadBundleRepo_RepositoryUri}
+    build_cluster_arn: ${BuildClusterWorkloadArn}
+    iterate_cluster_arn: ${IterateClusterWorkloadArn}
+EOF
+popd
+pushd "$tap_dir/src/resources"
+aws s3 cp --no-progress --recursive --exclude '*' --include '*.yaml' "${QSS3BucketPath}/src/resources/" .
+cat <<EOF > ./workload-aws.yaml
+${SampleAppConfig}
+EOF
+popd
+chown -R $user:$user "$tap_dir"
+echo "Installing pivnet CLI..."
+wget -O "$tap_dir/downloads/pivnet" "https://github.com/pivotal-cf/pivnet-cli/releases/download/v${PivNetVersion}/pivnet-linux-$(dpkg --print-architecture)-${PivNetVersion}"
+install -o $user -g $user -m 0755 "$tap_dir/downloads/pivnet" /usr/local/bin/pivnet
+echo "Installing Tanzu CLI and Staging Tanzu-cluster-essentials..."
+su - $user -c "$tap_dir/src/install-tools.sh"
+echo TanzuNetRelocateImages ${TanzuNetRelocateImages}
+if [[ "${TanzuNetRelocateImages}" == "Yes" ]]
+then
+  echo "Creating local copies of key TAP container repos per VMware best practices..."
+  su - $user -c "$tap_dir/src/tap-relocate.sh"
+fi
+
+echo "Installing Tanzu Application Platform..."
+echo ClusterArch ${ClusterArch}
+if [[ "${ClusterArch}" == "multi" ]]
+then
+  echo "Setup TAP Multiple Clusters..."
+  su - $user -c "$tap_dir/src/tap-main.sh -c install view"
+  su - $user -c "$tap_dir/src/tap-main.sh -c install run"
+  su - $user -c "$tap_dir/src/tap-main.sh -c install build"
+  su - $user -c "$tap_dir/src/tap-main.sh -c install iterate"
+  su - $user -c "$tap_dir/src/tap-main.sh -c prepview view"
+  cfnSignal 0 "${TAPInstallHandle}"
+
+  su - $user -c "$tap_dir/src/tap-main.sh -c installwk iterate"
+  su - $user -c "$tap_dir/src/tap-main.sh -c installwk build"
+  su - $user -c "$tap_dir/src/tap-main.sh -c installwk run"
+  echo "wait till the workload to go through the supply-chain (8mins)"
+  sleep 480
+  cfnSignal 0 "${TAPWorkloadInstallHandle}"
+
+  su - $user -c "$tap_dir/src/tap-main.sh -c runtests run"
+  su - $user -c "$tap_dir/src/tap-main.sh -c runtests iterate"
+  cfnSignal 0 "${TAPTestsHandle}"
+else
+  echo "Setup TAP Single Cluster..."
+  su - $user -c "$tap_dir/src/tap-main.sh -c install single"
+  cfnSignal 0 "${TAPInstallHandle}"
+
+  su - $user -c "$tap_dir/src/tap-main.sh -c installwk single"
+  echo "wait till the workload to go through the supply-chain (8mins)"
+  sleep 480
+  cfnSignal 0 "${TAPWorkloadInstallHandle}"
+
+  su - $user -c "$tap_dir/src/tap-main.sh -c runtests single"
+  cfnSignal 0 "${TAPTestsHandle}"
+fi
+
+echo "Completed successfully!"

--- a/templates/aws-tap-entrypoint-existing-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-existing-vpc.template.yaml
@@ -2451,23 +2451,18 @@ Resources:
 
               local rc="${!1:-42}"
               local handleURL="${!2:-${CloudInitHandle}}"
-              local args=(
-                --region "${!AWS_REGION}"
-                --exit-code "$rc"
-              )
+              local reason='installation succeeded'
+              local ctxLines=10
 
-              if (( rc == 0 )) ; then
-                args+=(
-                  --reason "tap-install: succeeded"
-                )
-              else
-                args+=(
-                  --reason "tap-install: failed"
-                  --data "[...] $( tail -n 6 /var/log/cloud-init-output.log )"
-                )
-              fi
+              (( rc != 0 )) && {
+                local nl=$'\n'
+                # We don't care about the last 3 lines of the log, because
+                # that's logging the cfnSignal itself.
+                reason="${!nl}$( tail -n $(( ctxLines + 3 )) /var/log/cloud-init-output.log | head -n -3 )${!nl}"
+              }
 
-              cfn-signal "${!args[@]}" "$handleURL" || echo >&2 'could not run cfn-signal'
+              cfn-signal --region "${!AWS_REGION}" --exit-code "$rc" --reason "$reason" "$handleURL" \
+                || echo >&2 'could not run cfn-signal'
             }
             export -f cfnSignal
             trap 'cfnSignal $?' ERR

--- a/templates/aws-tap-entrypoint-existing-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-existing-vpc.template.yaml
@@ -2328,230 +2328,157 @@ Resources:
         Fn::Base64: !Sub
           - |
             #!/bin/bash
-            set -xe
-            user=ubuntu
-            arch=$(dpkg --print-architecture)
-            uname=$(uname -m)
-            tap_dir=/home/$user/tap-setup-scripts
+            set -e
+            set -u
+            set -o pipefail
+
+            set -x
+
             cat <<EOF >> /etc/environment
             AWS_REGION=${AWS::Region}
             AWS_DEFAULT_REGION=${AWS::Region}
             EOF
-            set -a
-            source /etc/environment
+            . /etc/environment
+            export AWS_REGION AWS_DEFAULT_REGION
+
+            set +x
+              # TODO: we should ensure to
+              #       - only export actually used vars
+              #       - never print/log those, or at least sensitive ones
+              #       - use consistent/proper/clear var names
+              #       - handle multiline/quoted/... vars correctly
+              export AWSAccountID='${AWS::AccountId}'
+              export AwsKubectlVersion='${AwsKubectlVersion}'
+              export BuildClusterBuildServiceArn='${BuildClusterBuildServiceArn}'
+              export BuildClusterName='${BuildClusterName}'
+              export BuildClusterWorkloadArn='${BuildClusterWorkloadArn}'
+              export ClusterArch='${ClusterArch}'
+              export ClusterEssentialsBundleFileHash='${ClusterEssentialsBundleFileHash}'
+              export ClusterEssentialsBundleRepo='${ClusterEssentialsBundleRepo}'
+              export ClusterEssentialsBundleVersion='${ClusterEssentialsBundleVersion}'
+              export DockerCredPassVersion='${DockerCredPassVersion}'
+              export EKSClusterName='${EKSClusterName}'
+              export IterateClusterBuildServiceArn='${IterateClusterBuildServiceArn}'
+              export IterateClusterName='${IterateClusterName}'
+              export IterateClusterWorkloadArn='${IterateClusterWorkloadArn}'
+              export LinuxBastionSshPort='${LinuxBastionSshPort}'
+              export PivNetVersion='${PivNetVersion}'
+              export PrivateHostedZone='${PrivateHostedZone}'
+              export QSS3BucketPath='${QSS3BucketPath}'
+              export RunClusterName='${RunClusterName}'
+              export SampleAppConfig='${SampleAppConfig}'
+              export SampleAppName='${SampleAppName}'
+              export SampleAppNamespace='${SampleAppNamespace}'
+              export TAPBuildServiceRepo_RepositoryUri='${TAPBuildServiceRepo.RepositoryUri}'
+              export TAPClusterEssentialsBundleRepo_RepositoryUri='${TAPClusterEssentialsBundleRepo.RepositoryUri}'
+              export TAPDomainName='${TAPDomainName}'
+              export TAPLogGroup='${TAPLogGroup}'
+              export TAPPackagesRepo_RepositoryUri='${TAPPackagesRepo.RepositoryUri}'
+              export TAPRepo='${TAPRepo}'
+              export TAPVersion='${TAPVersion}'
+              export TAPWorkloadRepo_RepositoryUri='${TAPWorkloadRepo.RepositoryUri}'
+              export TanzuNetRegistryServer='${TanzuNetRegistryServer}'
+              export TanzuNetRelocateImages='${TanzuNetRelocateImages}'
+              export TanzuNetSecretCredentials='${TanzuNetSecretCredentials}'
+              export ViewClusterName='${ViewClusterName}'
+
+              # WaitConditionHanldes
+              export CloudInitHandle='${CloudInitHandle}'
+              export TAPInstallHandle='${TAPInstallHandle}'
+              export TAPWorkloadInstallHandle='${TAPWorkloadInstallHandle}'
+              export TAPTestsHandle='${TAPTestsHandle}'
+            set -x
+
+            arch=$(dpkg --print-architecture)
+
             echo "Removing built-in Docker..."
             apt-get -y remove containerd runc
+
             echo "Adding Docker CE repo..."
             mkdir -p /usr/local/share/keyrings/
             curl -fsSL https://download.docker.com/linux/ubuntu/gpg |
               gpg --dearmor -o /usr/local/share/keyrings/docker-archive-keyring.gpg --yes
             printf "deb [arch=$arch signed-by=/usr/local/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" |
               tee /etc/apt/sources.list.d/docker.list
+
             echo "Updating & upgrading..."
             apt-get -y update
             apt-get -y upgrade
+
             echo "Installing system dependencies..."
-            apt-get -y install amazon-ecr-credential-helper ca-certificates containerd.io curl docker-ce \
-              docker-ce-cli docker-compose-plugin git gnupg gnupg2 jq lsb-release openssl pass perl python3-pip \
-              python3-setuptools sed sudo traceroute unzip uuid-runtime vim wget
+            apt-get -y install \
+              amazon-ecr-credential-helper \
+              ca-certificates \
+              containerd.io \
+              curl \
+              docker-ce \
+              docker-ce-cli \
+              docker-compose-plugin \
+              git \
+              gnupg \
+              gnupg2 \
+              jq \
+              lsb-release \
+              openssl \
+              pass \
+              perl \
+              python3-pip \
+              python3-setuptools \
+              sed \
+              sudo \
+              traceroute \
+              unzip \
+              uuid-runtime \
+              vim \
+              wget
+
+            # TODO: use mktemp and a trap to clean up (or use an AMI with AWS CLI preinstalled)
+            # Note: the Ubuntu AMI seems to come with `wget` and `curl` already installed
             echo "Installing aws cli..."
             pushd /tmp
-            wget -O "./awscliv2.zip" "https://awscli.amazonaws.com/awscli-exe-linux-$uname.zip"
+            wget -O "./awscliv2.zip" "https://awscli.amazonaws.com/awscli-exe-linux-$(uname -m).zip"
             unzip ./awscliv2.zip
             ./aws/install
             popd
-            echo "Installing python dependencies for $user..."
-            su - $user -c "mkdir -p /home/$user/.local/bin; source /home/$user/.profile; python3 -m pip install --upgrade pip setuptools wheel yq"
-            echo "Updating certificate authority certificates..."
-            update-ca-certificates
-            echo "Installing Amazon CloudWatch agent..."
-            mkdir -p /opt/aws/amazon-cloudwatch-agent/etc/
-            cat <<EOF >> /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json
-            {
-              "metrics": {
-                "append_dimensions": {
-                  "ImageId": "\${!aws:ImageId}",
-                  "InstanceId": "\${!aws:InstanceId}",
-                  "InstanceType": "\${!aws:InstanceType}"
-                },
-                "metrics_collected": {
-                  "mem": {
-                    "measurement": [
-                      "mem_used_percent"
-                    ]
-                  },
-                  "swap": {
-                    "measurement": [
-                      "swap_used_percent"
-                    ]
-                  }
-                }
-              },
-              "logs": {
-                "logs_collected": {
-                  "files": {
-                    "collect_list": [
-                      {
-                        "file_path": "/var/log/cloud-init-output.log",
-                        "log_group_name": "${TAPLogGroup}",
-                        "log_stream_name": "{instance_id}_/var/log/cloud-init-output.log"
-                      }
-                    ]
-                  }
-                }
-              }
+
+            echo "Installing aws-cfn-bootstrap tools & setting signal trap"
+            pip3 install "https://s3.${!AWS_REGION}.amazonaws.com/cloudformation-examples/aws-cfn-bootstrap-py3-latest.tar.gz"
+
+            # Set and export the cfn trap
+            cfnSignal() {
+              local -
+              set +x
+
+              local rc="${!1:-42}"
+              local handleURL="${!2:-${CloudInitHandle}}"
+              local args=(
+                --region "${!AWS_REGION}"
+                --exit-code "$rc"
+              )
+
+              if (( rc == 0 )) ; then
+                args+=(
+                  --reason "tap-install: succeeded"
+                )
+              else
+                args+=(
+                  --reason "tap-install: failed"
+                  --data "[...] $( tail -n 6 /var/log/cloud-init-output.log )"
+                )
+              fi
+
+              cfn-signal "${!args[@]}" "$handleURL" || echo >&2 'could not run cfn-signal'
             }
-            EOF
-            pushd /tmp
-            aws s3 cp --no-progress "s3://amazoncloudwatch-agent-${AWS::Region}/ubuntu/$arch/latest/amazon-cloudwatch-agent.deb" ./amazon-cloudwatch-agent.deb
-            dpkg -i ./amazon-cloudwatch-agent.deb
-            popd
-            /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl -a fetch-config -m ec2 -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json -s
-            systemctl enable amazon-cloudwatch-agent.service
-            systemctl start amazon-cloudwatch-agent.service
-            systemctl status amazon-cloudwatch-agent.service
-            echo "Installing kubectl..."
-            pushd /tmp
-            aws s3 cp --no-progress "s3://amazon-eks/${AwsKubectlVersion}/bin/linux/$arch/kubectl" ./kubectl
-            aws s3 cp --no-progress "s3://amazon-eks/${AwsKubectlVersion}/bin/linux/$arch/kubectl.sha256" ./kubectl.sha256
-            openssl sha1 -sha256 ./kubectl
-            chmod 755 ./kubectl
-            mv ./kubectl /usr/local/bin/
-            kubectl completion bash > /etc/bash_completion.d/kubectl
-            popd
-            echo "Configuring Docker..."
-            getent group docker || groupadd docker
-            usermod -aG docker $user
-            mkdir -p /root/.docker
-            su - $user -c "mkdir -p /home/$user/.docker"
-            pushd /tmp
-            curl -fsSL "https://github.com/docker/docker-credential-helpers/releases/download/v${DockerCredPassVersion}/docker-credential-pass-v${DockerCredPassVersion}-$arch.tar.gz" | tar xz -C .
-            mv docker-credential-pass /usr/local/bin/
-            popd
-            cat <<EOF > /root/.docker/config.json
-            {
-              "credHelpers": {
-                "${AWS::AccountId}.dkr.ecr.${AWS::Region}.amazonaws.com": "ecr-login",
-                "public.ecr.aws": "ecr-login"
-              }
-            }
-            EOF
-            cp /root/.docker/config.json /home/$user/.docker/
-            chown $user:$user /home/$user/.docker/config.json
-            echo "Configuring the SSH listening port..."
-            printf "Port ${LinuxBastionSshPort}\n" > /etc/ssh/sshd_config.d/port.conf
-            systemctl restart sshd.service
-            systemctl status sshd.service
-            echo "Downloading the VMware Tanzu Application Platform Quick Start scripts..."
-            su - $user -c "mkdir -p \"$tap_dir/downloads\" \"$tap_dir/generated\" \"$tap_dir/src/inputs\" \"$tap_dir/src/resources\""
-            pushd "$tap_dir/src"
-            aws s3 cp --no-progress "${QSS3BucketPath}/src/tap-main.sh" ./tap-main.sh
-            chmod +x ./tap-main.sh
-            aws s3 cp --no-progress "${QSS3BucketPath}/src/tap-relocate.sh" ./tap-relocate.sh
-            chmod +x ./tap-relocate.sh
-            aws s3 cp --no-progress "${QSS3BucketPath}/src/install-tools.sh" ./install-tools.sh
-            chmod +x ./install-tools.sh
-            aws s3 cp --no-progress "${QSS3BucketPath}/src/functions.sh" ./functions.sh
-            popd
-            pushd "$tap_dir/src/inputs"
-            aws s3 cp --no-progress "${QSS3BucketPath}/src/inputs/tap-values-build.yaml" ./tap-values-build.yaml
-            aws s3 cp --no-progress "${QSS3BucketPath}/src/inputs/tap-values-run.yaml" ./tap-values-run.yaml
-            aws s3 cp --no-progress "${QSS3BucketPath}/src/inputs/tap-values-iterate.yaml" ./tap-values-iterate.yaml
-            aws s3 cp --no-progress "${QSS3BucketPath}/src/inputs/tap-values-view.yaml" ./tap-values-view.yaml
-            aws s3 cp --no-progress "${QSS3BucketPath}/src/inputs/tap-values-single.yaml" ./tap-values-single.yaml
-            echo "Logging script input parameters"
-            echo ClusterArch ${ClusterArch}
-            echo BuildClusterBuildServiceArn ${BuildClusterBuildServiceArn}
-            echo BuildClusterWorkloadArn ${BuildClusterWorkloadArn}
-            echo IterateClusterBuildServiceArn ${IterateClusterBuildServiceArn}
-            echo IterateClusterWorkloadArn ${IterateClusterWorkloadArn}
-            echo BuildClusterName ${BuildClusterName}
-            echo RunClusterName ${RunClusterName}
-            echo ViewClusterName ${ViewClusterName}
-            echo IterateClusterName ${IterateClusterName}
-            cat <<EOF > ./user-input-values.yaml
-            #@data/values
-            ---
-            tanzunet:
-              server: ${TanzuNetRegistryServer}
-              relocate_images: "${TanzuNetRelocateImages}"
-              secrets:
-                credentials_arn: ${TanzuNetSecretCredentials}
-            cluster_essentials_bundle:
-              bundle: ${TanzuNetRegistryServer}/${ClusterEssentialsBundleRepo}
-              file_hash: ${ClusterEssentialsBundleFileHash}
-              version: ${ClusterEssentialsBundleVersion}
-            tap:
-              name: tap
-              namespace: tap-install
-              repository: ${TanzuNetRegistryServer}/${TAPRepo}
-              version: ${TAPVersion}
-            cluster:
-              arch: ${ClusterArch}
-              name: ${EKSClusterName}
-            buildservice:
-              build_cluster_arn: ${BuildClusterBuildServiceArn}
-              iterate_cluster_arn: ${IterateClusterBuildServiceArn}
-            dns:
-              domain_name: ${TAPDomainName}
-              zone_id: ${PrivateHostedZone}
-            repositories:
-              tap_packages: ${TAPPackagesRepo.RepositoryUri}
-              cluster_essentials: ${TAPClusterEssentialsBundleRepo.RepositoryUri}
-              build_service: ${TAPBuildServiceRepo.RepositoryUri}
-              workload:
-                name: ${SampleAppName}
-                namespace: ${SampleAppNamespace}
-                repository: ${TAPWorkloadRepo.RepositoryUri}
-                bundle_repository: ${TAPWorkloadBundleRepo.RepositoryUri}
-                build_cluster_arn: ${BuildClusterWorkloadArn}
-                iterate_cluster_arn: ${IterateClusterWorkloadArn}
-            EOF
-            popd
-            pushd "$tap_dir/src/resources"
-            aws s3 cp --no-progress --recursive --exclude '*' --include '*.yaml' "${QSS3BucketPath}/src/resources/" .
-            cat <<EOF > ./workload-aws.yaml
-            ${SampleAppConfig}
-            EOF
-            popd
-            chown -R $user:$user "$tap_dir"
-            echo "Installing pivnet CLI..."
-            wget -O "$tap_dir/downloads/pivnet" "https://github.com/pivotal-cf/pivnet-cli/releases/download/v${PivNetVersion}/pivnet-linux-$(dpkg --print-architecture)-${PivNetVersion}"
-            install -o $user -g $user -m 0755 "$tap_dir/downloads/pivnet" /usr/local/bin/pivnet
-            echo "Installing Tanzu CLI and Staging Tanzu-cluster-essentials..."
-            su - $user -c "$tap_dir/src/install-tools.sh"
-            echo TanzuNetRelocateImages ${TanzuNetRelocateImages}
-            if [[ "${TanzuNetRelocateImages}" == "Yes" ]]
-            then
-              echo "Creating local copies of key TAP container repos per VMware best practices..."
-              su - $user -c "$tap_dir/src/tap-relocate.sh"
-            fi
-            echo "Installing Tanzu Application Platform..."
-            echo ClusterArch ${ClusterArch}
-            if [[ "${ClusterArch}" == "multi" ]]
-            then
-              echo "Setup TAP Multiple Clusters..."
-              su - $user -c "$tap_dir/src/tap-main.sh -c install view"
-              su - $user -c "$tap_dir/src/tap-main.sh -c install run"
-              su - $user -c "$tap_dir/src/tap-main.sh -c install build"
-              su - $user -c "$tap_dir/src/tap-main.sh -c install iterate"
-              su - $user -c "$tap_dir/src/tap-main.sh -c prepview view"
-              su - $user -c "$tap_dir/src/tap-main.sh -c installwk iterate"
-              su - $user -c "$tap_dir/src/tap-main.sh -c installwk build"
-              su - $user -c "$tap_dir/src/tap-main.sh -c installwk run"
-              echo "wait till the workload to go through the supply-chain (8mins)"
-              sleep 480
-              su - $user -c "$tap_dir/src/tap-main.sh -c runtests run"
-              su - $user -c "$tap_dir/src/tap-main.sh -c runtests iterate"
-            else
-              echo "Setup TAP Single Cluster..."
-              su - $user -c "$tap_dir/src/tap-main.sh -c install single"
-              su - $user -c "$tap_dir/src/tap-main.sh -c installwk single"
-              echo "wait till the workload to go through the supply-chain (8mins)"
-              sleep 480
-              su - $user -c "$tap_dir/src/tap-main.sh -c runtests single"
-            fi
-            echo "Completed successfully!"
+            export -f cfnSignal
+            trap 'cfnSignal $?' ERR
+
+            cInit="${!QSS3BucketPath}/src/cloud-init.sh"
+            echo "kicking off cloud-init from '${!cInit}'"
+            bash -xe <(
+              aws s3 cp --no-progress "${!cInit}" -
+            )
+
+            cfnSignal 0
           - AwsKubectlVersion: !FindInMap [KubernetesVersion, !Ref KubernetesVersion, AwsKubectlVersion]
             ClusterEssentialsBundleRepo: tanzu-cluster-essentials/cluster-essentials-bundle
             ClusterEssentialsBundleFileHash: !FindInMap [ClusterEssentialsBundle, !FindInMap [TAPVersion, !Ref TAPVersion, ClusterEssentialsBundleVersion], FileHash]
@@ -2574,6 +2501,60 @@ Resources:
             IterateClusterWorkloadArn: !If [CreateMultiCluster, !GetAtt ITERATEWorkloadIamRole.Arn, ""]
             RunClusterName: !If [CreateMultiCluster, !GetAtt RUNEKSQSStack.Outputs.EKSClusterName, ""]
             ViewClusterName: !If [CreateMultiCluster, !GetAtt VIEWEKSQSStack.Outputs.EKSClusterName, ""]
+
+            CloudInitHandle:          !Ref PhaseCloudInitHandle
+            TAPInstallHandle:         !Ref PhaseTAPInstallHandle
+            TAPWorkloadInstallHandle: !Ref PhaseTAPWorkloadInstallHandle
+            TAPTestsHandle:           !Ref PhaseTAPTestsHandle
+
+  # Phase for the whole cloud-init process
+  # from the creation of the instance to finished cloud-init run
+  PhaseCloudInitHandle:
+    Type: AWS::CloudFormation::WaitConditionHandle
+  PhaseCloudInit:
+    Type: AWS::CloudFormation::WaitCondition
+    DependsOn: UbuntuBastion
+    Properties:
+      Count: 1
+      Handle: !Ref "PhaseCloudInitHandle"
+      Timeout: "3600" # 60m
+
+  # Phase for TAP install
+  # from the creation of the instance to finished TAP install
+  PhaseTAPInstallHandle:
+    Type: AWS::CloudFormation::WaitConditionHandle
+  PhaseTAPInstall:
+    Type: AWS::CloudFormation::WaitCondition
+    DependsOn: UbuntuBastion
+    Properties:
+      Count: 1
+      Handle: !Ref "PhaseTAPInstallHandle"
+      Timeout: "1800" # 30m
+
+  # Phase for TAP workload install
+  # from finished TAP install to finished workload deployment
+  PhaseTAPWorkloadInstallHandle:
+    Type: AWS::CloudFormation::WaitConditionHandle
+  PhaseTAPWorkloadInstall:
+    Type: AWS::CloudFormation::WaitCondition
+    DependsOn: PhaseTAPInstall
+    Properties:
+      Count: 1
+      Handle: !Ref "PhaseTAPWorkloadInstallHandle"
+      Timeout: "1200" # 20min
+
+  # Phase for TAP (smoke) tests
+  # from finished TAP workload deployment to finished test runs
+  PhaseTAPTestsHandle:
+    Type: AWS::CloudFormation::WaitConditionHandle
+  PhaseTAPTests:
+    Type: AWS::CloudFormation::WaitCondition
+    DependsOn: PhaseTAPWorkloadInstall
+    Properties:
+      Count: 1
+      Handle: !Ref "PhaseTAPTestsHandle"
+      Timeout: "600" # 10m
+
   UbuntuBastionEipAssociation:
     Type: AWS::EC2::EIPAssociation
     UpdateReplacePolicy: Delete


### PR DESCRIPTION
A couple of things are happening here:
1. We define some WaitConditions, for now
   - PhaseCloudInit
   - PhaseTAPInstall
   - PhaseTAPWorkloadInstall
   - PhaseTAPTests which get created at different times in the stack. E.g. the `PhaseCloudInit` gets created once the EC2 instance changed to `CREATE_COMPLETE`, however the `PhaseTAPWorkloadInstall` gets created once the `PhaseTAPInstall` goes into `CREATE_COMPLETE` (and thus signals that TAP installation has finished).
2. In the cloud-init we use `cfn-signal` to signal back success or failures to those WaitConditions respectively their related Handles, thus changing the status of those resources to `CREATE_COMPLETE` or `CREATE_FAILED`.
3. With that we can measure how long inidividual parts took to bring up. There is a task in the pipeline which pulls out some data about that. Once we agree on which data we should pull out, we can then also push that "somewhere" instead of only printing it.

Now to make this signaling via `cfn-signal` work, we need to pass in the `WaitConditionHandle` URLs into the instance's user-data. With those URLs being quite big, the maximum size of the user-data was exceeded. Thus we pulled out quite some stuff into a separate script, which we
- pull down from AWS
- launch from the inline user-data block

For now, the general approach is:
Inline pretty much only things we need to pull down the externalized cloud-init script (package and CLI installation), the setup of the signaling handler/trap, and exporting of variables the externalized cloud-init script needs.
The rest, pretty much everything related to setup and configuration of TAP itself, should go to the externalized cloud-init script.

This also has the side-effect, that we don't have to deal with shell-vars vs. cloudformation-subtitution-vars in the externalized script; we only have to deal with that in the inlined user-data.