### PR TITLE
Run the tests against `main` daily

### DIFF
--- a/ci/qs-test/pipeline.yml
+++ b/ci/qs-test/pipeline.yml
@@ -65,7 +65,7 @@ resources:
   type: time
   source:
     location: UTC
-    start: 05:00 AM
+    start: 04:00 AM
     stop: 06:00 AM
     days: [ Monday, Tuesday, Wednesday, Thursday, Friday ]
 

--- a/ci/qs-test/pipeline.yml
+++ b/ci/qs-test/pipeline.yml
@@ -188,6 +188,9 @@ jobs:
         submodules: none
       trigger: true
       passed: [ prepare-bucket ]
+    - get: daily-run
+      trigger: true
+      passed: [ prepare-bucket ]
   - *setup
   - task: taskcat-test
     file: ci-repo/ci/tasks/taskcat-run-test/task.yml
@@ -213,6 +216,9 @@ jobs:
     - get: repo
       params:
         submodules: none
+      trigger: true
+      passed: [ prepare-bucket ]
+    - get: daily-run
       trigger: true
       passed: [ prepare-bucket ]
   - *setup


### PR DESCRIPTION
We have to pass through the daily trigger to the test run jobs for concourse to actually run them daily, otherwise it would only prepare the bucket and stop there.

We don't pass the daily trigger to the publish-bucket job, tho; we really only need to do that when the repo's version changed.

So now, the test really run against repo's `main`, so you could consider that a soak test.