### PR TITLE
Update EKS k8s version to 1.24

### DIFF
--- a/templates/aws-tap-entrypoint-existing-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-existing-vpc.template.yaml
@@ -223,8 +223,9 @@ Parameters:
       refer to Kubernetes cluster requirements
       (https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.4/tap/prerequisites.html#kubernetes-cluster-requirements-3).
     AllowedValues:
-      - 1.23
-    Default: 1.23
+      - '1.23'
+      - '1.24'
+    Default: '1.24'
   NumberOfNodes:
     Type: Number
     Description: Minimum number of nodes to create for the TAP EKS cluster.
@@ -655,7 +656,9 @@ Mappings:
   KubernetesVersion:
   # https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html
     '1.23':
-      AwsKubectlVersion: 1.23.7/2022-06-29
+      AwsKubectlVersion: 1.23.15/2023-01-11
+    '1.24':
+      AwsKubectlVersion: 1.24.9/2023-01-11
   TAPVersion:
     1.4.0:
       ClusterEssentialsBundleVersion: 1.3.0
@@ -702,211 +705,6 @@ Conditions:
   # UseEcr: !Equals [!Ref TanzuNetRelocateImages, 'Yes']
   UsingDefaultBucket: !Equals [!Ref QSS3BucketName, aws-quickstart]
 Resources:
-  BUILDEKSEBSCSIDriverRole:
-    Type: AWS::IAM::Role
-    Condition: CreateMultiCluster
-    Properties:
-      RoleName: !Sub
-        - BUILDEKSEBSCSIDriverRole-${StackId}
-        - StackId: !Select [2, !Split [/, !Ref AWS::StackId]]
-      Description: >-
-        VMware Tanzu Application Platform role for EBSSCI Driver.
-      AssumeRolePolicyDocument: !Sub
-        - |
-          {
-            "Version": "2012-10-17",
-            "Statement": [
-              {
-                "Effect": "Allow",
-                "Principal": {
-                  "Federated": "${IamOidcProviderArn}/${OidcProviderEndpoint}"
-                },
-                "Action": "sts:AssumeRoleWithWebIdentity",
-                "Condition": {
-                  "StringEquals": {
-                    "${OidcProviderEndpoint}:aud": "sts.amazonaws.com",
-                    "${OidcProviderEndpoint}:sub": "system:serviceaccount:kube-system:ebs-csi-controller-sa"
-                  }
-                }
-              }
-            ]
-          }
-        - IamOidcProviderArn: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:oidc-provider
-          OidcProviderEndpoint: !Select [1, !Split [//, !GetAtt BUILDEKSQSStack.Outputs.OIDCIssuerURL]]
-      ManagedPolicyArns:
-        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy
-  RUNEKSEBSCSIDriverRole:
-    Type: AWS::IAM::Role
-    Condition: CreateMultiCluster
-    Properties:
-      RoleName: !Sub
-        - RUNEKSEBSCSIDriverRole-${StackId}
-        - StackId: !Select [2, !Split [/, !Ref AWS::StackId]]
-      Description: >-
-        VMware Tanzu Application Platform role for EBSSCI Driver.
-      AssumeRolePolicyDocument: !Sub
-        - |
-          {
-            "Version": "2012-10-17",
-            "Statement": [
-              {
-                "Effect": "Allow",
-                "Principal": {
-                  "Federated": "${IamOidcProviderArn}/${OidcProviderEndpoint}"
-                },
-                "Action": "sts:AssumeRoleWithWebIdentity",
-                "Condition": {
-                  "StringEquals": {
-                    "${OidcProviderEndpoint}:aud": "sts.amazonaws.com",
-                    "${OidcProviderEndpoint}:sub": "system:serviceaccount:kube-system:ebs-csi-controller-sa"
-                  }
-                }
-              }
-            ]
-          }
-        - IamOidcProviderArn: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:oidc-provider
-          OidcProviderEndpoint: !Select [1, !Split [//, !GetAtt RUNEKSQSStack.Outputs.OIDCIssuerURL]]
-      ManagedPolicyArns:
-        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy
-  VIEWEKSEBSCSIDriverRole:
-    Type: AWS::IAM::Role
-    Condition: CreateMultiCluster
-    Properties:
-      RoleName: !Sub
-        - VIEWEKSEBSCSIDriverRole-${StackId}
-        - StackId: !Select [2, !Split [/, !Ref AWS::StackId]]
-      Description: >-
-        VMware Tanzu Application Platform role for EBSSCI Driver.
-      AssumeRolePolicyDocument: !Sub
-        - |
-          {
-            "Version": "2012-10-17",
-            "Statement": [
-              {
-                "Effect": "Allow",
-                "Principal": {
-                  "Federated": "${IamOidcProviderArn}/${OidcProviderEndpoint}"
-                },
-                "Action": "sts:AssumeRoleWithWebIdentity",
-                "Condition": {
-                  "StringEquals": {
-                    "${OidcProviderEndpoint}:aud": "sts.amazonaws.com",
-                    "${OidcProviderEndpoint}:sub": "system:serviceaccount:kube-system:ebs-csi-controller-sa"
-                  }
-                }
-              }
-            ]
-          }
-        - IamOidcProviderArn: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:oidc-provider
-          OidcProviderEndpoint: !Select [1, !Split [//, !GetAtt VIEWEKSQSStack.Outputs.OIDCIssuerURL]]
-      ManagedPolicyArns:
-        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy
-  ITERATEEKSEBSCSIDriverRole:
-    Type: AWS::IAM::Role
-    Condition: CreateMultiCluster
-    Properties:
-      RoleName: !Sub
-        - ITERATEEKSEBSCSIDriverRole-${StackId}
-        - StackId: !Select [2, !Split [/, !Ref AWS::StackId]]
-      Description: >-
-        VMware Tanzu Application Platform role for EBSSCI Driver.
-      AssumeRolePolicyDocument: !Sub
-        - |
-          {
-            "Version": "2012-10-17",
-            "Statement": [
-              {
-                "Effect": "Allow",
-                "Principal": {
-                  "Federated": "${IamOidcProviderArn}/${OidcProviderEndpoint}"
-                },
-                "Action": "sts:AssumeRoleWithWebIdentity",
-                "Condition": {
-                  "StringEquals": {
-                    "${OidcProviderEndpoint}:aud": "sts.amazonaws.com",
-                    "${OidcProviderEndpoint}:sub": "system:serviceaccount:kube-system:ebs-csi-controller-sa"
-                  }
-                }
-              }
-            ]
-          }
-        - IamOidcProviderArn: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:oidc-provider
-          OidcProviderEndpoint: !Select [1, !Split [//, !GetAtt ITERATEEKSQSStack.Outputs.OIDCIssuerURL]]
-      ManagedPolicyArns:
-        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy
-  SINGLEEKSEBSCSIDriverRole:
-    Type: AWS::IAM::Role
-    Condition: CreateSingleCluster
-    Properties:
-      RoleName: !Sub
-        - SINGLEEKSEBSCSIDriverRole-${StackId}
-        - StackId: !Select [2, !Split [/, !Ref AWS::StackId]]
-      Description: >-
-        VMware Tanzu Application Platform role for EBSSCI Driver.
-      AssumeRolePolicyDocument: !Sub
-        - |
-          {
-            "Version": "2012-10-17",
-            "Statement": [
-              {
-                "Effect": "Allow",
-                "Principal": {
-                  "Federated": "${IamOidcProviderArn}/${OidcProviderEndpoint}"
-                },
-                "Action": "sts:AssumeRoleWithWebIdentity",
-                "Condition": {
-                  "StringEquals": {
-                    "${OidcProviderEndpoint}:aud": "sts.amazonaws.com",
-                    "${OidcProviderEndpoint}:sub": "system:serviceaccount:kube-system:ebs-csi-controller-sa"
-                  }
-                }
-              }
-            ]
-          }
-        - IamOidcProviderArn: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:oidc-provider
-          OidcProviderEndpoint: !Select [1, !Split [//, !GetAtt EKSQSStack.Outputs.OIDCIssuerURL]]
-      ManagedPolicyArns:
-        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy
-  BUILDEBSSCIAddon:
-    Type: AWS::EKS::Addon
-    Condition: CreateMultiCluster
-    Properties:
-      AddonName: aws-ebs-csi-driver
-      ClusterName: !Sub ${EKSClusterName}-build
-      ResolveConflicts: NONE
-      ServiceAccountRoleArn: !GetAtt BUILDEKSEBSCSIDriverRole.Arn
-  RUNEBSSCIAddon:
-    Type: AWS::EKS::Addon
-    Condition: CreateMultiCluster
-    Properties:
-      AddonName: aws-ebs-csi-driver
-      ClusterName: !Sub ${EKSClusterName}-run
-      ResolveConflicts: NONE
-      ServiceAccountRoleArn: !GetAtt RUNEKSEBSCSIDriverRole.Arn
-  VIEWEBSSCIAddon:
-    Type: AWS::EKS::Addon
-    Condition: CreateMultiCluster
-    Properties:
-      AddonName: aws-ebs-csi-driver
-      ClusterName: !Sub ${EKSClusterName}-view
-      ResolveConflicts: NONE
-      ServiceAccountRoleArn: !GetAtt VIEWEKSEBSCSIDriverRole.Arn
-  ITERATEEBSSCIAddon:
-    Type: AWS::EKS::Addon
-    Condition: CreateMultiCluster
-    Properties:
-      AddonName: aws-ebs-csi-driver
-      ClusterName: !Sub ${EKSClusterName}-iterate
-      ResolveConflicts: NONE
-      ServiceAccountRoleArn: !GetAtt ITERATEEKSEBSCSIDriverRole.Arn
-  SINGLEEBSSCIAddon:
-    Type: AWS::EKS::Addon
-    Condition: CreateSingleCluster
-    Properties:
-      AddonName: aws-ebs-csi-driver
-      ClusterName: !Ref EKSClusterName
-      ResolveConflicts: NONE
-      ServiceAccountRoleArn: !GetAtt SINGLEEKSEBSCSIDriverRole.Arn
   TanzuNetSecretCredentials:
     Type: AWS::SecretsManager::Secret
     Properties:

--- a/templates/aws-tap-entrypoint-existing-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-existing-vpc.template.yaml
@@ -34,7 +34,6 @@ Metadata:
       - Label:
           default: VMware Tanzu Application Platform configuration
         Parameters:
-          - TAPVersion
           - TAPDomainName
           - TAPClusterArch
       - Label:
@@ -118,8 +117,6 @@ Metadata:
         default: API token
       TanzuNetRelocateImages:
         default: Relocate TAP images
-      TAPVersion:
-        default: Version
       SampleAppName:
         default: Name
       QSS3BucketName:
@@ -493,9 +490,7 @@ Parameters:
   TAPVersion:
     Type: String
     Description: >-
-      Version of TAP to deploy. For more information, refer to Kubernetes
-      cluster requirements
-      (https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.4/tap/prerequisites.html#kubernetes-cluster-requirements-3).
+      Version of TAP to deploy.
     AllowedValues:
       - 1.4.0
     Default: 1.4.0

--- a/templates/aws-tap-entrypoint-existing-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-existing-vpc.template.yaml
@@ -209,12 +209,6 @@ Parameters:
       Minimum length of 1. Maximum length of 100. Must start with a letter or
       number.
     Default: cluster-eks-tap
-  KubernetesVersion:
-    Type: String
-    Description: The EKS/kubernetes version to run TAP on
-    AllowedValues:
-      - '1.24'
-    Default: '1.24'
   NumberOfNodes:
     Type: Number
     Description: Minimum number of nodes to create for the TAP EKS cluster.
@@ -487,13 +481,6 @@ Parameters:
       - 'Yes'
       - 'No'
     Default: 'No'
-  TAPVersion:
-    Type: String
-    Description: >-
-      Version of TAP to deploy.
-    AllowedValues:
-      - 1.4.0
-    Default: 1.4.0
   SampleAppName:
     Type: String
     Description: >-
@@ -544,6 +531,16 @@ Parameters:
      information, refer to https://aws-quickstart.github.io/option1.html.
     Default: us-east-1
 Mappings:
+  Versions:
+    current:
+      TAP: 1.4.0
+      EKS: '1.24'
+      # https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html
+      Kubectl: 1.24.9/2023-01-11
+      ClusterEssentialsVersion: 1.3.0
+      ClusterEssentialsHash: sha256:54bf611711923dccd7c7f10603c846782b90644d48f1cb570b43a082d18e23b9
+      PivNet: 3.0.1
+      DockerCredPass:  0.6.4
   AwsAmiRegionMap:
     af-south-1:
       US2204HVM: '{{resolve:ssm:/aws/service/canonical/ubuntu/server/22.04/stable/current/amd64/hvm/ebs-gp2/ami-id}}'
@@ -639,20 +636,6 @@ Mappings:
   TanzuNetRegistryServer:
     Server:
       Name: registry.tanzu.vmware.com
-  KubernetesVersion:
-  # https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html
-    '1.24':
-      AwsKubectlVersion: 1.24.9/2023-01-11
-  TAPVersion:
-    1.4.0:
-      ClusterEssentialsBundleVersion: 1.3.0
-  ClusterEssentialsBundle:
-    1.1.0:
-      FileHash: sha256:ab0a3539da241a6ea59c75c0743e9058511d7c56312ea3906178ec0f3491f51d
-    1.2.0:
-      FileHash: sha256:e00f33b92d418f49b1af79f42cb13d6765f1c8c731f4528dfff8343af042dc3e
-    1.3.0:
-      FileHash: sha256:54bf611711923dccd7c7f10603c846782b90644d48f1cb570b43a082d18e23b9
   SampleAppProperties:
     Namespace:
       Name: tap-workload
@@ -790,7 +773,7 @@ Resources:
       Parameters:
         ConfigSetName: !Ref AWS::StackName
         NodeVolumeSize: !Ref NodeVolumeSize
-        KubernetesVersion: !Ref KubernetesVersion
+        KubernetesVersion: !FindInMap [ Versions, current, EKS ]
   EKSQSStack:
     Type: AWS::CloudFormation::Stack
     Condition: CreateSingleCluster
@@ -2257,12 +2240,13 @@ Resources:
             )
 
             cfnSignal 0
-          - AwsKubectlVersion: !FindInMap [KubernetesVersion, !Ref KubernetesVersion, AwsKubectlVersion]
+          - AwsKubectlVersion: !FindInMap [ Versions, current, Kubectl ]
+            TAPVersion: !FindInMap [ Versions, current, TAP ]
             ClusterEssentialsBundleRepo: tanzu-cluster-essentials/cluster-essentials-bundle
-            ClusterEssentialsBundleFileHash: !FindInMap [ClusterEssentialsBundle, !FindInMap [TAPVersion, !Ref TAPVersion, ClusterEssentialsBundleVersion], FileHash]
-            ClusterEssentialsBundleVersion: !FindInMap [TAPVersion, !Ref TAPVersion, ClusterEssentialsBundleVersion]
-            DockerCredPassVersion: 0.6.4
-            PivNetVersion: 3.0.1
+            ClusterEssentialsBundleFileHash: !FindInMap [ Versions, current, ClusterEssentialsHash ]
+            ClusterEssentialsBundleVersion: !FindInMap [ Versions, current, ClusterEssentialsVersion ]
+            DockerCredPassVersion: !FindInMap [ Versions, current, DockerCredPass ]
+            PivNetVersion: !FindInMap [ Versions, current, PivNet ]
             SampleAppConfig: !FindInMap [SampleAppConfig, !Ref SampleAppName, Config]
             SampleAppNamespace: !FindInMap [SampleAppProperties, Namespace, Name]
             QSS3BucketPath: !Sub
@@ -2536,12 +2520,3 @@ Rules:
           You must acknowledge that you have read and accept the VMware
           Customer Experience Improvement Program (CEIP) policy before you can
           proceed with the installation.
-  TAPInterop:
-    RuleCondition: !Contains [[1.4.0], !Ref TAPVersion]
-    Assertions:
-      # The values below require quotes to force string comparison.
-      - Assert: !Contains [['1.22', '1.23', '1.24'], !Ref KubernetesVersion]
-        AssertDescription: >-
-          The VMware Tanzu Application Platform version selection is
-          incompatible with the Kubernetes version selection (reference:
-          https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.4/tap/prerequisites.html#kubernetes-cluster-requirements-3).

--- a/templates/aws-tap-entrypoint-existing-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-existing-vpc.template.yaml
@@ -58,7 +58,6 @@ Metadata:
           default: Amazon EKS configuration
         Parameters:
           - EKSClusterName
-          - KubernetesVersion
           - NodeInstanceType
           - NodeVolumeSize
           - NumberOfNodes
@@ -103,8 +102,6 @@ Metadata:
         default: EKS single or multi cluster
       EKSClusterName:
         default: EKS cluster name
-      KubernetesVersion:
-        default: Kubernetes version
       NodeInstanceType:
         default: Instance type
       NodeVolumeSize:
@@ -217,13 +214,8 @@ Parameters:
     Default: cluster-eks-tap
   KubernetesVersion:
     Type: String
-    Description: >-
-      Version of Kubernetes control plane to deploy. The selected version must
-      be supported the selected TAP version (TAPVersion). For more information,
-      refer to Kubernetes cluster requirements
-      (https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.4/tap/prerequisites.html#kubernetes-cluster-requirements-3).
+    Description: The EKS/kubernetes version to run TAP on
     AllowedValues:
-      - '1.23'
       - '1.24'
     Default: '1.24'
   NumberOfNodes:
@@ -501,9 +493,8 @@ Parameters:
   TAPVersion:
     Type: String
     Description: >-
-      Version of TAP to deploy. The selected version must also support the
-      selected Kubernetes version (KubernetesVersion). For more information,
-      refer to Kubernetes cluster requirements
+      Version of TAP to deploy. For more information, refer to Kubernetes
+      cluster requirements
       (https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.4/tap/prerequisites.html#kubernetes-cluster-requirements-3).
     AllowedValues:
       - 1.4.0
@@ -655,8 +646,6 @@ Mappings:
       Name: registry.tanzu.vmware.com
   KubernetesVersion:
   # https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html
-    '1.23':
-      AwsKubectlVersion: 1.23.15/2023-01-11
     '1.24':
       AwsKubectlVersion: 1.24.9/2023-01-11
   TAPVersion:

--- a/templates/aws-tap-entrypoint-new-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-new-vpc.template.yaml
@@ -62,7 +62,6 @@ Metadata:
           default: Amazon EKS configuration
         Parameters:
           - EKSClusterName
-          - KubernetesVersion
           - NodeInstanceType
           - NodeVolumeSize
           - NumberOfNodes
@@ -115,8 +114,6 @@ Metadata:
         default: EKS single or multi cluster
       EKSClusterName:
         default: EKS cluster name
-      KubernetesVersion:
-        default: Kubernetes version
       NodeInstanceType:
         default: Instance type
       NodeVolumeSize:
@@ -265,17 +262,6 @@ Parameters:
       Minimum length of 1. Maximum length of 100. Must start with a letter or
       number.
     Default: cluster-eks-tap
-  KubernetesVersion:
-    Type: String
-    Description: >-
-      Version of Kubernetes control plane to deploy. The selected version must
-      be supported the selected TAP version (TAPVersion). For more information,
-      refer to Kubernetes cluster requirements
-      (https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.4/tap/prerequisites.html#kubernetes-cluster-requirements-3).
-    AllowedValues:
-      - '1.23'
-      - '1.24'
-    Default: '1.24'
   NumberOfNodes:
     Type: Number
     Description: Minimum number of nodes to create for the TAP EKS cluster.
@@ -551,8 +537,7 @@ Parameters:
   TAPVersion:
     Type: String
     Description: >-
-      Version of TAP to deploy. The selected version must also support the
-      selected Kubernetes version (KubernetesVersion). For more information,
+      Version of TAP to deploy. For more information,
       refer to Kubernetes cluster requirements
       (https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.4/tap/prerequisites.html#kubernetes-cluster-requirements-3).
     AllowedValues:
@@ -660,7 +645,6 @@ Resources:
         NodeInstanceType: !Ref NodeInstanceType
         NodeVolumeSize: !Ref NodeVolumeSize
         EKSClusterName: !Ref EKSClusterName
-        KubernetesVersion: !Ref KubernetesVersion
         TAPDomainName: !Ref TAPDomainName
         TAPClusterArch: !Ref TAPClusterArch
         TanzuNetUsername: !Ref TanzuNetUsername
@@ -758,12 +742,3 @@ Rules:
           You must acknowledge that you have read and accepted the VMware
           Customer Experience Improvement Program (CEIP) policy before you can
           proceed with the installation.
-  TAPInterop:
-    RuleCondition: !Contains [[1.4.0], !Ref TAPVersion]
-    Assertions:
-      # The values below require quotes to force string comparison.
-      - Assert: !Contains [['1.22', '1.23', '1.24'], !Ref KubernetesVersion]
-        AssertDescription: >-
-          The VMware Tanzu Application Platform version selection is
-          incompatible with the Kubernetes version selection (reference:
-          https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.4/tap/prerequisites.html#kubernetes-cluster-requirements-3).

--- a/templates/aws-tap-entrypoint-new-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-new-vpc.template.yaml
@@ -273,8 +273,9 @@ Parameters:
       refer to Kubernetes cluster requirements
       (https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.4/tap/prerequisites.html#kubernetes-cluster-requirements-3).
     AllowedValues:
-      - 1.23
-    Default: 1.23
+      - '1.23'
+      - '1.24'
+    Default: '1.24'
   NumberOfNodes:
     Type: Number
     Description: Minimum number of nodes to create for the TAP EKS cluster.

--- a/templates/aws-tap-entrypoint-new-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-new-vpc.template.yaml
@@ -34,7 +34,6 @@ Metadata:
       - Label:
           default: VMware Tanzu Application Platform configuration
         Parameters:
-          - TAPVersion
           - TAPDomainName
           - TAPClusterArch
       - Label:
@@ -130,8 +129,6 @@ Metadata:
         default: API token
       TanzuNetRelocateImages:
         default: Relocate TAP images
-      TAPVersion:
-        default: Version
       SampleAppName:
         default: Name
       QSS3BucketName:
@@ -534,15 +531,6 @@ Parameters:
       - 'Yes'
       - 'No'
     Default: 'No'
-  TAPVersion:
-    Type: String
-    Description: >-
-      Version of TAP to deploy. For more information,
-      refer to Kubernetes cluster requirements
-      (https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.4/tap/prerequisites.html#kubernetes-cluster-requirements-3).
-    AllowedValues:
-      - 1.4.0
-    Default: 1.4.0
   SampleAppName:
     Type: String
     Description: >-
@@ -651,7 +639,6 @@ Resources:
         TanzuNetPassword: !Ref TanzuNetPassword
         TanzuNetApiToken: !Ref TanzuNetApiToken
         TanzuNetRelocateImages: !Ref TanzuNetRelocateImages
-        TAPVersion: !Ref TAPVersion
         SampleAppName: !Ref SampleAppName
         QSS3BucketName: !Ref QSS3BucketName
         QSS3BucketRegion: !Ref QSS3BucketRegion


### PR DESCRIPTION
- Bump EKS version to 1.24
  - needed to bump the submodule'd EKS stack to get 1.24 support
  - had the side effect, that CSI is already managed in the newer version, so we can remove that from our stack
- Remove Parameters `KubernetesVersion` & `TAPVersion`
  - after discussions with the team, we decided to remove those to parameters
  - I have ripped them out completely and centralized the version configuration in a `Mapping` ; for easier updates