### PR TITLE
Print stack create link in prepare-bucket task

### DIFF
--- a/ci/tasks/lib/misc.lib.sh
+++ b/ci/tasks/lib/misc.lib.sh
@@ -1,3 +1,5 @@
+# shellcheck shell=bash
+
 run::logged() {
   local msg="$1" ; shift
   local rc=0
@@ -13,4 +15,54 @@ run::logged() {
   echo >&2
 
   return $rc
+}
+
+uri::encode() {
+  jq -rn --arg data "$1" '$data | @uri'
+}
+
+bucket::printDetails() {
+  local bucket="${1?}"
+  local prefix="${2?}"
+  local region="${3?}"
+
+  local stackName="${4:-tap-internal}"
+
+  local urlTemplate urlParts
+
+  echo
+  echo "Published to 's3://${bucket}/${prefix}'"
+  echo
+
+  urlTemplate="https://${bucket}.s3.amazonaws.com/${prefix}templates/aws-tap-entrypoint-new-vpc.template.yaml"
+  urlParts=(
+    "https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate"
+    "?templateURL=$( uri::encode "$urlTemplate" )"
+    "&stackName=$( uri::encode "$stackName" )"
+    "&param_EKSClusterName=$( uri::encode "$stackName" )"
+    "&param_QSS3BucketName=$( uri::encode "$bucket" )"
+    "&param_QSS3BucketRegion=$( uri::encode "$region" )"
+    "&param_QSS3KeyPrefix=$( uri::encode "$prefix" )"
+  )
+
+  echo "Stack can be deployed via:"
+
+  echo
+  printf '%s' '  ' "${urlParts[@]}" $'\n'
+  echo
+
+  echo "    QSS3BucketName:   ${bucket}"
+  echo "    QSS3KeyPrefix:    ${prefix}"
+  echo "    QSS3BucketRegion: ${region}"
+}
+
+# Pulls bucket coordinates from a taskcat file and prints them, the bucket
+# name, the bucket prefix, and the region comma separated.
+# Can be consumed like this:
+#   mapfile -t -d $'\t' coords < <( bucket::getCoords .taskcat.yml )
+bucket::getCoords() {
+  local taskcatConfig="${1?}"
+  yq -jr \
+    '.project.parameters | [ .QSS3BucketName, .QSS3KeyPrefix, .QSS3BucketRegion ] | @tsv' \
+    "$taskcatConfig"
 }

--- a/ci/tasks/taskcat-bucket-sync/task.sh
+++ b/ci/tasks/taskcat-bucket-sync/task.sh
@@ -6,59 +6,27 @@ set -o pipefail
 
 # shellcheck disable=SC1091
 source creds/env.inc.sh
+# shellcheck disable=SC1091
+source ci-repo/ci/tasks/lib/misc.lib.sh
 
 ensureSingleTrailingSlash() {
   sed 's,/*$,/,g'
 }
 
-uriEncode() {
-  jq -rn --arg data "$1" '$data | @uri'
-}
-
 main() {
-  local region srcBucket
+  local srcBucketCoords
   local destBucket destBucketName destBucketPrefix
-  local urlParts urlTemplate stackName
 
-  region="$(
-    yq -r '.project.parameters.QSS3BucketRegion' taskcat-config/taskcat.yml
-  )"
-  srcBucket="$(
-    yq -r '.project.parameters | "\(.QSS3BucketName)/\(.QSS3KeyPrefix)"' taskcat-config/taskcat.yml
-  )"
+  mapfile -t -d $'\t' srcBucketCoords \
+    < <( bucket::getCoords taskcat-config/taskcat.yml )
 
-  srcBucket="$( ensureSingleTrailingSlash <<< "$srcBucket" )"
   destBucket="$( ensureSingleTrailingSlash <<< "${DESTINATION_BUCKET?}" )"
   destBucketName="${destBucket%%/*}"
   destBucketPrefix="${destBucket#*/}"
 
-  aws s3 sync "s3://${srcBucket}" "s3://${destBucket}"
+  aws s3 sync "s3://${srcBucketCoords[0]}/${srcBucketCoords[1]}" "s3://${destBucket}"
 
-  echo
-  echo "Published to 's3://${destBucket}'"
-  echo
-
-  stackName='tap-internal'
-  urlTemplate="https://${destBucketName}.s3.amazonaws.com/${destBucketPrefix}templates/aws-tap-entrypoint-new-vpc.template.yaml"
-  urlParts=(
-    "https://console.aws.amazon.com/cloudformation/home#/stacks/quickcreate"
-    "?templateURL=$( uriEncode "$urlTemplate" )"
-    "&stackName=$( uriEncode "$stackName" )"
-    "&param_EKSClusterName=$( uriEncode "$stackName" )"
-    "&param_QSS3BucketName=$( uriEncode "$destBucketName" )"
-    "&param_QSS3BucketRegion=$( uriEncode "$region" )"
-    "&param_QSS3KeyPrefix=$( uriEncode "$destBucketPrefix" )"
-  )
-
-  echo "Stack can be deployed via:"
-
-  echo
-  printf '%s' '  ' "${urlParts[@]}" $'\n'
-  echo
-
-  echo "    QSS3BucketName:   ${destBucketName}"
-  echo "    QSS3KeyPrefix:    ${destBucketPrefix}"
-  echo "    QSS3BucketRegion: ${region}"
+  bucket::printDetails "$destBucketName" "$destBucketPrefix" "${srcBucketCoords[2]}"
 }
 
 main "$@"


### PR DESCRIPTION
So that we can quickly kick of a manual/one-off deployment from a prepared bucket.