### PR TITLE
Introduce some tests in the pipeline before we kick off e2e

### DIFF
--- a/ci/qs-test/pipeline.yml
+++ b/ci/qs-test/pipeline.yml
@@ -108,7 +108,7 @@ alerting:
 
 groups:
 - name: main
-  jobs: [ prepare-bucket, test-single, test-multi, publish-bucket, set-pipeline ]
+  jobs: [ prepare-bucket, test-static, test-single, test-multi, publish-bucket, set-pipeline ]
 - name: pr
   jobs: [ "pr-*", set-pipeline ]
 - name: housekeeping
@@ -130,9 +130,8 @@ jobs:
     - ci-repo/ci/qs-test/pipeline.vars.yml
 
 #! ---> main ----
-- name: prepare-bucket
+- name: test-static
   << : *alertingOnJobs
-  serial: true
   plan:
   - in_parallel:
     - get: daily-run
@@ -143,6 +142,24 @@ jobs:
       passed: [ set-pipeline ]
     - get: repo
       trigger: true
+  - task: test-static
+    file: ci-repo/ci/tasks/test-static.yml
+- name: prepare-bucket
+  << : *alertingOnJobs
+  serial: true
+  plan:
+  - in_parallel:
+    - get: daily-run
+      trigger: true
+      passed: [ test-static ]
+    - get: ci-repo
+      params:
+        submodules: none
+      trigger: true
+      passed: [ test-static ]
+    - get: repo
+      trigger: true
+      passed: [ test-static ]
   - &setup
     in_parallel:
     - &getCloudGateCreds
@@ -257,9 +274,8 @@ jobs:
     get_params:
       skip_download: true
 
-- name: pr-prepare-bucket
+- name: pr-test-static
   << : *alertginOnPrJobs
-  serial: true
   plan:
   - in_parallel:
     - get: ci-repo
@@ -268,6 +284,23 @@ jobs:
       passed: [ set-pipeline ]
     - get: repo
       passed: [ pr-set-pending ]
+      resource: pull-request
+      trigger: true
+  - task: test-static
+    file: ci-repo/ci/tasks/test-static.yml
+
+- name: pr-prepare-bucket
+  << : *alertginOnPrJobs
+  serial: true
+  plan:
+  - in_parallel:
+    - get: ci-repo
+      params:
+        submodules: none
+      trigger: true
+      passed: [ pr-test-static ]
+    - get: repo
+      passed: [ pr-test-static ]
       resource: pull-request
       trigger: true
   - in_parallel:

--- a/ci/tasks/test-static/task.sh
+++ b/ci/tasks/test-static/task.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -e
+set -u
+set -o pipefail
+
+main() {
+  local -a tests
+  local t
+  local rc=0
+
+  tests=(
+    "${PWD}/ci-repo/ci/tests/static/templates.sh"
+  )
+
+  cd repo
+
+  for t in "${tests[@]}" ; do
+    REPO_DIR="${PWD}" "$t" || rc=$(( rc | $? ))
+  done
+
+  return $rc
+}
+
+main "$@"

--- a/ci/tasks/test-static/task.yml
+++ b/ci/tasks/test-static/task.yml
@@ -1,0 +1,12 @@
+---
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    repository: tappc-docker-local.artifactory.eng.vmware.com/ci/docker-image
+    tag: latest
+inputs:
+- name: ci-repo
+- name: repo
+run:
+  path: ci-repo/ci/tasks/test-static/task.sh

--- a/ci/tests/static/templates.sh
+++ b/ci/tests/static/templates.sh
@@ -10,12 +10,19 @@ set -e
 set -u
 set -o pipefail
 
-DIR="$( cd "$(dirname "${BASH_SOURCE[0]}")" && pwd )"
-readonly DIR
+REPO_DIR="${REPO_DIR:-$( cd "$(dirname "${BASH_SOURCE[0]}")" && cd ../../../ && pwd )}"
+readonly REPO_DIR
 
 # shellcheck disable=SC2034
-readonly TEMPLATE_NEW_VPC="${DIR}/../../../templates/aws-tap-entrypoint-new-vpc.template.yaml"
-readonly TEMPLATE_EXISTING_VPC="${DIR}/../../../templates/aws-tap-entrypoint-existing-vpc.template.yaml"
+readonly TEMPLATE_NEW_VPC="${REPO_DIR}/templates/aws-tap-entrypoint-new-vpc.template.yaml"
+readonly TEMPLATE_EXISTING_VPC="${REPO_DIR}/templates/aws-tap-entrypoint-existing-vpc.template.yaml"
+
+##--------------------------------------------------------------------
+Test::CloudformationLint() {
+  cd "$REPO_DIR"
+  find templates/ -type f -iregex '.*\.ya?ml' -print0 \
+    | xargs -0 -r cfn-lint
+}
 
 ##--------------------------------------------------------------------
 # Test if all substacks we create get configured with the correct bucket


### PR DESCRIPTION
This, for now, just runs some linting and other static checks.

In the future we will probably introduce more tests (e.g. inclusive-lang, shellcheck, unit tests, ...) which should probably run as additional `test-...` jobs in parallel to the `test-static` job, so that they can all run and be re-triggered in isolation.