### PR TITLE
Bump TAP & dependencies

### DIFF
--- a/tap-setup-scripts/src/cloud-init.sh
+++ b/tap-setup-scripts/src/cloud-init.sh
@@ -74,10 +74,8 @@ getent group docker || groupadd docker
 usermod -aG docker $user
 mkdir -p /root/.docker
 su - $user -c "mkdir -p /home/$user/.docker"
-pushd /tmp
-curl -fsSL "https://github.com/docker/docker-credential-helpers/releases/download/v${DockerCredPassVersion}/docker-credential-pass-v${DockerCredPassVersion}-$arch.tar.gz" | tar xz -C .
-mv docker-credential-pass /usr/local/bin/
-popd
+dockerCredHelperURI="https://github.com/docker/docker-credential-helpers/releases/download/v${DockerCredPassVersion}/docker-credential-pass-v${DockerCredPassVersion}.linux-${arch}"
+install -m 0750 <( curl -fsSL "$dockerCredHelperURI" ) /usr/local/bin/docker-credential-pass
 
 
 cat <<EOF > /root/.docker/config.json

--- a/templates/aws-tap-entrypoint-existing-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-existing-vpc.template.yaml
@@ -533,7 +533,7 @@ Parameters:
 Mappings:
   Versions:
     current:
-      TAP: 1.4.0
+      TAP: 1.4.1
       EKS: '1.24'
       #! https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html
       Kubectl: 1.24.9/2023-01-11

--- a/templates/aws-tap-entrypoint-existing-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-existing-vpc.template.yaml
@@ -535,10 +535,13 @@ Mappings:
     current:
       TAP: 1.4.0
       EKS: '1.24'
-      # https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html
+      #! https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html
       Kubectl: 1.24.9/2023-01-11
-      ClusterEssentialsVersion: 1.3.0
-      ClusterEssentialsHash: sha256:54bf611711923dccd7c7f10603c846782b90644d48f1cb570b43a082d18e23b9
+      ClusterEssentialsVersion: 1.4.1
+      #! Note: this is not the hash of the pivnet artifact, but rather the image hash for the bundle image;
+      #! You can get it e.g. by 
+      #!   docker pull registry.tanzu.vmware.com/tanzu-cluster-essentials/cluster-essentials-bundle:1.4.1
+      ClusterEssentialsHash: sha256:2354688e46d4bb4060f74fca069513c9b42ffa17a0a6d5b0dbb81ed52242ea44
       PivNet: 3.0.1
       DockerCredPass:  0.6.4
   AwsAmiRegionMap:

--- a/templates/aws-tap-entrypoint-existing-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-existing-vpc.template.yaml
@@ -543,7 +543,7 @@ Mappings:
       #!   docker pull registry.tanzu.vmware.com/tanzu-cluster-essentials/cluster-essentials-bundle:1.4.1
       ClusterEssentialsHash: sha256:2354688e46d4bb4060f74fca069513c9b42ffa17a0a6d5b0dbb81ed52242ea44
       PivNet: 3.0.1
-      DockerCredPass:  0.6.4
+      DockerCredPass:  0.7.0
   AwsAmiRegionMap:
     af-south-1:
       US2204HVM: '{{resolve:ssm:/aws/service/canonical/ubuntu/server/22.04/stable/current/amd64/hvm/ebs-gp2/ami-id}}'


### PR DESCRIPTION
- Bump ClusterEssentials to 1.4.1
- Bump docker-credential-helpers to 0.7.0
- Bump TAP to 1.4.1