### PR TITLE
adding table for cf keys and descriptions in post deployment guide

### DIFF
--- a/docs/deployment_guide/partner_editable/post_deployment.adoc
+++ b/docs/deployment_guide/partner_editable/post_deployment.adoc
@@ -420,6 +420,9 @@
 
 |`WindowsBastionEIP`
 |The Elastic IP address associated with the Windows bastion host instance.
+
+|`TAPWorkloadUrl`
+|The sample workload URL accessible from the Windows bastion instance.
 |====
 
 === Security configuration and management tasks

--- a/docs/deployment_guide/partner_editable/post_deployment.adoc
+++ b/docs/deployment_guide/partner_editable/post_deployment.adoc
@@ -357,7 +357,7 @@
 
 //|`NumberOfNodes`
 //|Number of nodes
-//|`3` 
+//|`3`
 //|Minimum number of nodes to create for each {partner-product-acronym} EKS cluster.
 
 //|`MaxNumberOfNodes`
@@ -407,10 +407,20 @@
 
 === CloudFormation outputs
 
-After deployment, refer to the *Outputs* tab in the AWS CloudFormation console for the following information:
+[%autowidth.stretch]
+.CloudFormation outputs
+|====
+|Key |Description
 
-. The Elastic IP addresses associated with the Amazon EC2 Linux and Windows bastion host instances.
-. The {partner-product-short-name} website URL. For more information, refer to <<Access the {partner-product-name} user interface>>, later in this guide.
+|`TAPGuiUrl`
+|The {partner-product-short-name} graphical user interface URL. For more information, refer to <<Access the {partner-product-name} user interface>>, later in this guide.
+
+|`LinuxBastionEIP`
+|The Elastic IP address associated with the Amazon EC2 Linux instance.
+
+|`WindowsBastionEIP`
+|The Elastic IP address associated with the Windows bastion host instance.
+|====
 
 === Security configuration and management tasks
 


### PR DESCRIPTION
* added a table to postdeployment doc with notable cloudformation key names and descriptions 
* links to https://jira.eng.vmware.com/browse/TAPPC-181
![Screen Shot 2023-02-16 at 12 53 03 PM](https://user-images.githubusercontent.com/10872273/219460565-eed3be37-d100-4b48-8b84-a3f7e3adf7f0.png)

