### PR TITLE
Adapt to changed test names

### DIFF
--- a/ci/qs-test/pipeline.yml
+++ b/ci/qs-test/pipeline.yml
@@ -212,7 +212,7 @@ jobs:
   - task: taskcat-test
     file: ci-repo/ci/tasks/taskcat-run-test/task.yml
     params:
-      TEST_NAME: single
+      TEST_NAME: single-cluster
     ensure: &postTest
       in_parallel:
       - task: print-logs
@@ -244,7 +244,7 @@ jobs:
   - task: taskcat-test
     file: ci-repo/ci/tasks/taskcat-run-test/task.yml
     params:
-      TEST_NAME: multi
+      TEST_NAME: multi-cluster
     ensure: *postTest
 
 - name: publish-bucket
@@ -340,7 +340,7 @@ jobs:
   - task: taskcat-test
     file: ci-repo/ci/tasks/taskcat-run-test/task.yml
     params:
-      TEST_NAME: single
+      TEST_NAME: single-cluster
     ensure: *postTest
 
 - name: pr-test-multi
@@ -361,7 +361,7 @@ jobs:
   - task: taskcat-test
     file: ci-repo/ci/tasks/taskcat-run-test/task.yml
     params:
-      TEST_NAME: multi
+      TEST_NAME: multi-cluster
     ensure: *postTest
 
 - name: pr-set-success


### PR DESCRIPTION
Now that we use the "main" taskcat config, instead of a separate one for CI, we need to adapt to the slightly different test names.

Side-note: We could also dynamically pull out the test names from the taskcat config, run load_vars, and the across step ... but that's for another day.