### PR TITLE
update 'prepview' for k8 v1.24 & fetch PR-495

### DIFF
--- a/ci/qs-test/taskcat_overlay.yml
+++ b/ci/qs-test/taskcat_overlay.yml
@@ -43,7 +43,7 @@ project:
     TanzuNetRelocateImages: "No"
     TAPDomainName: #@ "{}.{}".format("$[taskcat_random-string]", domain)
     QSS3BucketName: #@ bucket + "-" + bucketRegion
-    QSS3BucketRegion: #@ bucketRegion
+    QSS3BucketRegion:  $[taskcat_current_region]
     QSS3KeyPrefix: #@ gitSha + "/"
   tags:
     gitSha: #@ gitSha

--- a/tap-setup-scripts/src/resources/tap-gui-viewer-secret.yaml
+++ b/tap-setup-scripts/src/resources/tap-gui-viewer-secret.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: tap-gui-viewer
+  namespace: tap-gui
+  annotations:
+    kubernetes.io/service-account.name: tap-gui-viewer
+type: kubernetes.io/service-account-token

--- a/templates/aws-tap-entrypoint-existing-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-existing-vpc.template.yaml
@@ -811,8 +811,7 @@ Resources:
         NodeGroupOS: Amazon Linux 2
         EKSClusterName: !Ref EKSClusterName
         ClusterAutoScaler: Enabled
-        MonitoringStack: None
-        ALBIngressController: Enabled
+        LoadBalancerController: Enabled
 #eks stacks multi cluster start
   RUNEKSQSStack:
     Type: AWS::CloudFormation::Stack
@@ -848,8 +847,7 @@ Resources:
         NodeGroupOS: Amazon Linux 2
         EKSClusterName: !Sub ${EKSClusterName}-run
         ClusterAutoScaler: Enabled
-        MonitoringStack: None
-        ALBIngressController: Enabled
+        LoadBalancerController: Enabled
   VIEWEKSQSStack:
     Type: AWS::CloudFormation::Stack
     Condition: CreateMultiCluster
@@ -884,8 +882,7 @@ Resources:
         NodeGroupOS: Amazon Linux 2
         EKSClusterName: !Sub ${EKSClusterName}-view
         ClusterAutoScaler: Enabled
-        MonitoringStack: None
-        ALBIngressController: Enabled
+        LoadBalancerController: Enabled
   BUILDEKSQSStack:
     Type: AWS::CloudFormation::Stack
     Condition: CreateMultiCluster
@@ -920,8 +917,7 @@ Resources:
         NodeGroupOS: Amazon Linux 2
         EKSClusterName: !Sub ${EKSClusterName}-build
         ClusterAutoScaler: Enabled
-        MonitoringStack: None
-        ALBIngressController: Enabled
+        LoadBalancerController: Enabled
   ITERATEEKSQSStack:
     Type: AWS::CloudFormation::Stack
     Condition: CreateMultiCluster
@@ -956,8 +952,7 @@ Resources:
         NodeGroupOS: Amazon Linux 2
         EKSClusterName: !Sub ${EKSClusterName}-iterate
         ClusterAutoScaler: Enabled
-        MonitoringStack: None
-        ALBIngressController: Enabled
+        LoadBalancerController: Enabled
 #eks stacks for multi cluster end
 #Rules for multi cluster start
   RunLinuxBastionSshToNodesEgressRule:


### PR DESCRIPTION

- CLUSTER_TOKEN value (kubectl command) is changed in Kubernetes cluster v1.24 or later.

> More details [here](https://docs.vmware.com/en/VMware-Tanzu-Application-Platform/1.4/tap/tap-gui-cluster-view-setup.html).
> This was causing prepview to fail internally. The fix updates the new token command/resources.

- To fetch changes in [PR-495](https://github.com/aws-quickstart/quickstart-amazon-eks/pull/495), updated the quickstart-amazon-eks submodule to commit#17cddfb.
These have fixes to cleanup all resources on the CFT stack delete operation
> 
> This PR has breaking changes, params have changed.
> 1) ALBIngressController to LoadBalancerController
> 2) MonitoringStack is removed.