### PR TITLE
Tappc190 remove unnecessary params from new vpc template

### DIFF
--- a/tap-setup-scripts/src/cloud-init.sh
+++ b/tap-setup-scripts/src/cloud-init.sh
@@ -88,10 +88,6 @@ cat <<EOF > /root/.docker/config.json
 EOF
 cp /root/.docker/config.json /home/$user/.docker/
 chown $user:$user /home/$user/.docker/config.json
-echo "Configuring the SSH listening port..."
-printf "Port ${LinuxBastionSshPort}\n" > /etc/ssh/sshd_config.d/port.conf
-systemctl restart sshd.service
-systemctl status sshd.service
 echo "Downloading the VMware Tanzu Application Platform Quick Start scripts..."
 su - $user -c "mkdir -p \"$tap_dir/downloads\" \"$tap_dir/generated\" \"$tap_dir/src/inputs\" \"$tap_dir/src/resources\""
 pushd "$tap_dir/src"

--- a/templates/aws-tap-entrypoint-existing-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-existing-vpc.template.yaml
@@ -605,6 +605,8 @@ Mappings:
     Server:
       Name: registry.tanzu.vmware.com
   SampleAppProperties:
+    SampleAppName:
+      Name: tanzu-java-web-app-workload
     Namespace:
       Name: tap-workload
     OotbRepoPrefix:
@@ -698,8 +700,9 @@ Resources:
         - StackId: !Select [2, !Split [/, !Ref AWS::StackId]]
           Prefix: !FindInMap [SampleAppProperties, OotbRepoPrefix, Name]
           Suffix: !Sub
-            - 'tanzu-java-web-app-workload-${Namespace}'
+            - '${SampleAppName}-${Namespace}'
             - Namespace: !FindInMap [SampleAppProperties, Namespace, Name]
+            - SampleAppName: !FindInMap [SampleAppProperties, SampleAppName, Name]
       EncryptionConfiguration:
         EncryptionType: AES256
   TAPWorkloadBundleRepo:
@@ -713,8 +716,9 @@ Resources:
         - StackId: !Select [2, !Split [/, !Ref AWS::StackId]]
           Prefix: !FindInMap [SampleAppProperties, OotbRepoPrefix, Name]
           Suffix: !Sub
-            - 'tanzu-java-web-app-workload-${Namespace}'
+            - '${SampleAppName}-${Namespace}'
             - Namespace: !FindInMap [SampleAppProperties, Namespace, Name]
+            - SampleAppName: !FindInMap [SampleAppProperties, SampleAppName, Name]
       EncryptionConfiguration:
         EncryptionType: AES256
   PrivateHostedZone:
@@ -2093,6 +2097,7 @@ Resources:
               export RunClusterName='${RunClusterName}'
               export SampleAppConfig='${SampleAppConfig}'
               export SampleAppNamespace='${SampleAppNamespace}'
+              export SampleAppName='${SampleAppName}'
               export TAPBuildServiceRepo_RepositoryUri='${TAPBuildServiceRepo.RepositoryUri}'
               export TAPClusterEssentialsBundleRepo_RepositoryUri='${TAPClusterEssentialsBundleRepo.RepositoryUri}'
               export TAPDomainName='${TAPDomainName}'
@@ -2207,6 +2212,7 @@ Resources:
             PivNetVersion: !FindInMap [ Versions, current, PivNet ]
             SampleAppConfig: !FindInMap [SampleAppConfig, tanzu-java-web-app-workload, Config]
             SampleAppNamespace: !FindInMap [SampleAppProperties, Namespace, Name]
+            SampleAppName: !FindInMap [SampleAppProperties, SampleAppName, Name]
             QSS3BucketPath: !Sub
               - s3://${S3Bucket}/${QSS3KeyPrefix}tap-setup-scripts
               - S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
@@ -2418,9 +2424,10 @@ Outputs:
       The URL of the VMware Tanzu Application Platform sample workload that is
       accessible from within the VPC, such as the Windows bastion instance.
     Value: !Sub
-      - http://tanzu-java-web-app-workload.${Namespace}${ClusterName}.${TAPDomainName}
+      - http://${SampleAppName}.${Namespace}${ClusterName}.${TAPDomainName}
       - ClusterName: !If [CreateMultiCluster, .run, '']
         Namespace: !FindInMap [SampleAppProperties, Namespace, Name]
+        SampleAppName: !FindInMap [SampleAppProperties, SampleAppName, Name]
   WindowsBastionAZ:
     Description: >-
       The Availability Zone that the Windows bastion instance is deployed in.

--- a/templates/aws-tap-entrypoint-existing-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-existing-vpc.template.yaml
@@ -702,7 +702,7 @@ Resources:
           Suffix: !Sub
             - '${SampleAppName}-${Namespace}'
             - Namespace: !FindInMap [SampleAppProperties, Namespace, Name]
-            - SampleAppName: !FindInMap [SampleAppProperties, SampleAppName, Name]
+              SampleAppName: !FindInMap [SampleAppProperties, SampleAppName, Name]
       EncryptionConfiguration:
         EncryptionType: AES256
   TAPWorkloadBundleRepo:
@@ -718,7 +718,7 @@ Resources:
           Suffix: !Sub
             - '${SampleAppName}-${Namespace}'
             - Namespace: !FindInMap [SampleAppProperties, Namespace, Name]
-            - SampleAppName: !FindInMap [SampleAppProperties, SampleAppName, Name]
+              SampleAppName: !FindInMap [SampleAppProperties, SampleAppName, Name]
       EncryptionConfiguration:
         EncryptionType: AES256
   PrivateHostedZone:

--- a/templates/aws-tap-entrypoint-existing-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-existing-vpc.template.yaml
@@ -591,16 +591,6 @@ Mappings:
     us-west-2:
       US2204HVM: '{{resolve:ssm:/aws/service/canonical/ubuntu/server/22.04/stable/current/amd64/hvm/ebs-gp2/ami-id}}'
       WS2022FullBase: '{{resolve:ssm:/aws/service/ami-windows-latest/Windows_Server-2022-English-Full-Base}}'
-  AwsAmiNameMap:
-    Ubuntu-Server-22.04-LTS-HVM:
-    # Official AMI name pattern is 'ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-????????'
-    # Alternative: Ubuntu Server lookup: https://cloud-images.ubuntu.com/locator/ec2/
-      Code: US2204HVM
-      OS: Ubuntu
-    Windows-Server-2022-English-Full-Base:
-    # Official AMI name pattern is 'Windows_Server-2022-English-Full-Base-????.??.??'
-      Code: WS2022FullBase
-      OS: Windows
   TanzuNetRegistryServer:
     Server:
       Name: registry.tanzu.vmware.com
@@ -2032,10 +2022,7 @@ Resources:
     Properties:
       InstanceType: m5.large
       IamInstanceProfile: !Ref LinuxBastionInstanceProfile
-      ImageId: !FindInMap
-        - AwsAmiRegionMap
-        - !Ref AWS::Region
-        - !FindInMap [AwsAmiNameMap, Ubuntu-Server-22.04-LTS-HVM, Code]
+      ImageId: !FindInMap [AwsAmiRegionMap, !Ref AWS::Region, US2204HVM]
       KeyName: !Ref KeyPairName
       Monitoring: true
       SecurityGroupIds:

--- a/templates/aws-tap-entrypoint-existing-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-existing-vpc.template.yaml
@@ -1164,6 +1164,8 @@ Resources:
       GroupId: !Ref LinuxBastionSecurityGroup
       IpProtocol: tcp
       CidrIp: !Ref RemoteAccessCidr
+      FromPort: 22
+      ToPort: 22
   LinuxBastionDefaultEgressRule:
     Type: AWS::EC2::SecurityGroupEgress
     UpdateReplacePolicy: Delete

--- a/templates/aws-tap-entrypoint-existing-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-existing-vpc.template.yaml
@@ -62,11 +62,6 @@ Metadata:
           - NumberOfNodes
           - MaxNumberOfNodes
       - Label:
-          default: Linux bastion host / bootstrap instance configuration
-        Parameters:
-          - LinuxBastionOS
-          - LinuxBastionSshPort
-      - Label:
           default: AWS Quick Start S3 bucket configuration
         Parameters:
           - QSS3BucketName
@@ -91,10 +86,6 @@ Metadata:
         default: Public subnet 1 ID
       RemoteAccessCidr:
         default: Remote access CIDR
-      LinuxBastionOS:
-        default: OS
-      LinuxBastionSshPort:
-        default: SSH port
       TAPDomainName:
         default: Domain name
       TAPClusterArch:
@@ -438,19 +429,6 @@ Parameters:
       hosts. We recommend that you set this value to a trusted network.
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$
     ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/0-32
-  LinuxBastionOS:
-    Type: String
-    Description: >-
-      Operating system for the Linux bastion host / bootstrap instance.
-    AllowedValues:
-      - Ubuntu-Server-22.04-LTS-HVM
-    Default: Ubuntu-Server-22.04-LTS-HVM
-  LinuxBastionSshPort:
-    Type: Number
-    Description: TCP port to use for the Linux bastion host listening port.
-    MinValue: 0
-    MaxValue: 65535
-    Default: 22
   TanzuNetUsername:
     Type: String
     Description: >-
@@ -539,7 +517,7 @@ Mappings:
       Kubectl: 1.24.9/2023-01-11
       ClusterEssentialsVersion: 1.4.1
       #! Note: this is not the hash of the pivnet artifact, but rather the image hash for the bundle image;
-      #! You can get it e.g. by 
+      #! You can get it e.g. by
       #!   docker pull registry.tanzu.vmware.com/tanzu-cluster-essentials/cluster-essentials-bundle:1.4.1
       ClusterEssentialsHash: sha256:2354688e46d4bb4060f74fca069513c9b42ffa17a0a6d5b0dbb81ed52242ea44
       PivNet: 3.0.1
@@ -669,7 +647,6 @@ Conditions:
   CreateMultiCluster: !Equals [!Ref TAPClusterArch, multi]
   CreateSingleCluster: !Equals [!Ref TAPClusterArch, single]
   3AZDeployment: !Not [!Equals [!Ref PrivateSubnet3Id, '']]
-  Ubuntu: !Equals [!FindInMap [AwsAmiNameMap, !Ref LinuxBastionOS, OS], Ubuntu]
   # TODO: Finish building logic to only deploy ECR-related resources if when
   # necessary.
   # UseEcr: !Equals [!Ref TanzuNetRelocateImages, 'Yes']
@@ -1209,8 +1186,6 @@ Resources:
       Description: Allow SSH to the Linux bastion host / bootstrap instance.
       GroupId: !Ref LinuxBastionSecurityGroup
       IpProtocol: tcp
-      FromPort: !Ref LinuxBastionSshPort
-      ToPort: !Ref LinuxBastionSshPort
       CidrIp: !Ref RemoteAccessCidr
   LinuxBastionDefaultEgressRule:
     Type: AWS::EC2::SecurityGroupEgress
@@ -2069,7 +2044,7 @@ Resources:
       ImageId: !FindInMap
         - AwsAmiRegionMap
         - !Ref AWS::Region
-        - !FindInMap [AwsAmiNameMap, !Ref LinuxBastionOS, Code]
+        - !FindInMap [AwsAmiNameMap, Ubuntu-Server-22.04-LTS-HVM, Code]
       KeyName: !Ref KeyPairName
       Monitoring: true
       SecurityGroupIds:
@@ -2125,7 +2100,6 @@ Resources:
               export IterateClusterBuildServiceArn='${IterateClusterBuildServiceArn}'
               export IterateClusterName='${IterateClusterName}'
               export IterateClusterWorkloadArn='${IterateClusterWorkloadArn}'
-              export LinuxBastionSshPort='${LinuxBastionSshPort}'
               export PivNetVersion='${PivNetVersion}'
               export PrivateHostedZone='${PrivateHostedZone}'
               export QSS3BucketPath='${QSS3BucketPath}'
@@ -2318,7 +2292,6 @@ Resources:
   UbuntuBastionEipAssociation:
     Type: AWS::EC2::EIPAssociation
     UpdateReplacePolicy: Delete
-    Condition: Ubuntu
     Properties:
       InstanceId: !Ref UbuntuBastion
       AllocationId: !GetAtt LinuxBastionEIP.AllocationId

--- a/templates/aws-tap-entrypoint-existing-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-existing-vpc.template.yaml
@@ -37,10 +37,6 @@ Metadata:
           - TAPDomainName
           - TAPClusterArch
       - Label:
-          default: Sample app configuration
-        Parameters:
-          - SampleAppName
-      - Label:
           default: Basic configuration
         Parameters:
           - KeyPairName
@@ -108,8 +104,6 @@ Metadata:
         default: API token
       TanzuNetRelocateImages:
         default: Relocate TAP images
-      SampleAppName:
-        default: Name
       QSS3BucketName:
         default: Name
       QSS3BucketRegion:
@@ -459,13 +453,6 @@ Parameters:
       - 'Yes'
       - 'No'
     Default: 'No'
-  SampleAppName:
-    Type: String
-    Description: >-
-      Name of the sample application to deploy into your Amazon EKS cluster.
-    AllowedValues:
-      - tanzu-java-web-app-workload
-    Default: tanzu-java-web-app-workload
   QSS3BucketName:
     Type: String
     Description: >-
@@ -711,7 +698,7 @@ Resources:
         - StackId: !Select [2, !Split [/, !Ref AWS::StackId]]
           Prefix: !FindInMap [SampleAppProperties, OotbRepoPrefix, Name]
           Suffix: !Sub
-            - '${SampleAppName}-${Namespace}'
+            - 'tanzu-java-web-app-workload-${Namespace}'
             - Namespace: !FindInMap [SampleAppProperties, Namespace, Name]
       EncryptionConfiguration:
         EncryptionType: AES256
@@ -726,7 +713,7 @@ Resources:
         - StackId: !Select [2, !Split [/, !Ref AWS::StackId]]
           Prefix: !FindInMap [SampleAppProperties, OotbRepoPrefix, Name]
           Suffix: !Sub
-            - '${SampleAppName}-${Namespace}'
+            - 'tanzu-java-web-app-workload-${Namespace}'
             - Namespace: !FindInMap [SampleAppProperties, Namespace, Name]
       EncryptionConfiguration:
         EncryptionType: AES256
@@ -2105,7 +2092,6 @@ Resources:
               export QSS3BucketPath='${QSS3BucketPath}'
               export RunClusterName='${RunClusterName}'
               export SampleAppConfig='${SampleAppConfig}'
-              export SampleAppName='${SampleAppName}'
               export SampleAppNamespace='${SampleAppNamespace}'
               export TAPBuildServiceRepo_RepositoryUri='${TAPBuildServiceRepo.RepositoryUri}'
               export TAPClusterEssentialsBundleRepo_RepositoryUri='${TAPClusterEssentialsBundleRepo.RepositoryUri}'
@@ -2219,7 +2205,7 @@ Resources:
             ClusterEssentialsBundleVersion: !FindInMap [ Versions, current, ClusterEssentialsVersion ]
             DockerCredPassVersion: !FindInMap [ Versions, current, DockerCredPass ]
             PivNetVersion: !FindInMap [ Versions, current, PivNet ]
-            SampleAppConfig: !FindInMap [SampleAppConfig, !Ref SampleAppName, Config]
+            SampleAppConfig: !FindInMap [SampleAppConfig, tanzu-java-web-app-workload, Config]
             SampleAppNamespace: !FindInMap [SampleAppProperties, Namespace, Name]
             QSS3BucketPath: !Sub
               - s3://${S3Bucket}/${QSS3KeyPrefix}tap-setup-scripts
@@ -2432,7 +2418,7 @@ Outputs:
       The URL of the VMware Tanzu Application Platform sample workload that is
       accessible from within the VPC, such as the Windows bastion instance.
     Value: !Sub
-      - http://${SampleAppName}.${Namespace}${ClusterName}.${TAPDomainName}
+      - http://tanzu-java-web-app-workload.${Namespace}${ClusterName}.${TAPDomainName}
       - ClusterName: !If [CreateMultiCluster, .run, '']
         Namespace: !FindInMap [SampleAppProperties, Namespace, Name]
   WindowsBastionAZ:

--- a/templates/aws-tap-entrypoint-existing-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-existing-vpc.template.yaml
@@ -594,15 +594,11 @@ Mappings:
   TanzuNetRegistryServer:
     Server:
       Name: registry.tanzu.vmware.com
-  SampleAppProperties:
-    SampleAppName:
+  Apps:
+    Sample:
       Name: tanzu-java-web-app-workload
-    Namespace:
-      Name: tap-workload
-    OotbRepoPrefix:
-      Name: tap-supply-chain
-  SampleAppConfig:
-    tanzu-java-web-app-workload:
+      Namespace: tap-workload
+      OotbRepoPrefix: tap-supply-chain
       Config: |
         apiVersion: carto.run/v1alpha1
         kind: Workload
@@ -688,11 +684,11 @@ Resources:
       RepositoryName: !Sub
         - '${StackId}/${Prefix}/${Suffix}'
         - StackId: !Select [2, !Split [/, !Ref AWS::StackId]]
-          Prefix: !FindInMap [SampleAppProperties, OotbRepoPrefix, Name]
+          Prefix: !FindInMap [Apps, Sample, OotbRepoPrefix]
           Suffix: !Sub
             - '${SampleAppName}-${Namespace}'
-            - Namespace: !FindInMap [SampleAppProperties, Namespace, Name]
-              SampleAppName: !FindInMap [SampleAppProperties, SampleAppName, Name]
+            - Namespace: !FindInMap [Apps, Sample, Namespace]
+              SampleAppName: !FindInMap [Apps, Sample, Name]
       EncryptionConfiguration:
         EncryptionType: AES256
   TAPWorkloadBundleRepo:
@@ -704,11 +700,11 @@ Resources:
       RepositoryName: !Sub
         - '${StackId}/${Prefix}/${Suffix}-bundle'
         - StackId: !Select [2, !Split [/, !Ref AWS::StackId]]
-          Prefix: !FindInMap [SampleAppProperties, OotbRepoPrefix, Name]
+          Prefix: !FindInMap [Apps, Sample, OotbRepoPrefix]
           Suffix: !Sub
             - '${SampleAppName}-${Namespace}'
-            - Namespace: !FindInMap [SampleAppProperties, Namespace, Name]
-              SampleAppName: !FindInMap [SampleAppProperties, SampleAppName, Name]
+            - Namespace: !FindInMap [Apps, Sample, Namespace]
+              SampleAppName: !FindInMap [Apps, Sample, Name]
       EncryptionConfiguration:
         EncryptionType: AES256
   PrivateHostedZone:
@@ -2197,9 +2193,9 @@ Resources:
             ClusterEssentialsBundleVersion: !FindInMap [ Versions, current, ClusterEssentialsVersion ]
             DockerCredPassVersion: !FindInMap [ Versions, current, DockerCredPass ]
             PivNetVersion: !FindInMap [ Versions, current, PivNet ]
-            SampleAppConfig: !FindInMap [SampleAppConfig, tanzu-java-web-app-workload, Config]
-            SampleAppNamespace: !FindInMap [SampleAppProperties, Namespace, Name]
-            SampleAppName: !FindInMap [SampleAppProperties, SampleAppName, Name]
+            SampleAppConfig: !FindInMap [Apps, Sample, Config]
+            SampleAppNamespace: !FindInMap [Apps, Sample, Namespace]
+            SampleAppName: !FindInMap [Apps, Sample, Name]
             QSS3BucketPath: !Sub
               - s3://${S3Bucket}/${QSS3KeyPrefix}tap-setup-scripts
               - S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
@@ -2413,8 +2409,8 @@ Outputs:
     Value: !Sub
       - http://${SampleAppName}.${Namespace}${ClusterName}.${TAPDomainName}
       - ClusterName: !If [CreateMultiCluster, .run, '']
-        Namespace: !FindInMap [SampleAppProperties, Namespace, Name]
-        SampleAppName: !FindInMap [SampleAppProperties, SampleAppName, Name]
+        Namespace: !FindInMap [Apps, Sample, Namespace]
+        SampleAppName: !FindInMap [Apps, Sample, Name]
   WindowsBastionAZ:
     Description: >-
       The Availability Zone that the Windows bastion instance is deployed in.

--- a/templates/aws-tap-entrypoint-new-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-new-vpc.template.yaml
@@ -590,8 +590,6 @@ Resources:
           - !Ref AWS::NoValue
         PublicSubnet1Id: !GetAtt VPCStack.Outputs.PublicSubnet1ID
         RemoteAccessCidr: !Ref RemoteAccessCidr
-        LinuxBastionOS: Ubuntu-Server-22.04-LTS-HVM
-        LinuxBastionSshPort: 22
         KeyPairName: !Ref KeyPairName
         NumberOfNodes: !Ref NumberOfNodes
         MaxNumberOfNodes: !Ref MaxNumberOfNodes

--- a/templates/aws-tap-entrypoint-new-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-new-vpc.template.yaml
@@ -37,10 +37,6 @@ Metadata:
           - TAPDomainName
           - TAPClusterArch
       - Label:
-          default: Sample app configuration
-        Parameters:
-          - SampleAppName
-      - Label:
           default: Basic configuration
         Parameters:
           - AvailabilityZones
@@ -65,11 +61,6 @@ Metadata:
           - NodeVolumeSize
           - NumberOfNodes
           - MaxNumberOfNodes
-      - Label:
-          default: Linux bastion host / bootstrap instance configuration
-        Parameters:
-          - LinuxBastionOS
-          - LinuxBastionSshPort
       - Label:
           default: AWS Quick Start S3 bucket configuration
         Parameters:
@@ -103,10 +94,6 @@ Metadata:
         default: Public subnet 3 CIDR
       RemoteAccessCidr:
         default: Remote access CIDR
-      LinuxBastionOS:
-        default: OS
-      LinuxBastionSshPort:
-        default: SSH port
       TAPDomainName:
         default: Domain name
       TAPClusterArch:
@@ -129,8 +116,6 @@ Metadata:
         default: API token
       TanzuNetRelocateImages:
         default: Relocate TAP images
-      SampleAppName:
-        default: Name
       QSS3BucketName:
         default: Name
       QSS3BucketRegion:
@@ -488,19 +473,6 @@ Parameters:
       hosts. We recommend that you set this value to a trusted network.
     AllowedPattern: ^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(3[0-2]|[1-2][0-9]|[0-9]))$
     ConstraintDescription: CIDR block parameter must be in the form x.x.x.x/0-32
-  LinuxBastionOS:
-    Type: String
-    Description: >-
-      Operating system for the Linux bastion host / bootstrap instance.
-    AllowedValues:
-      - Ubuntu-Server-22.04-LTS-HVM
-    Default: Ubuntu-Server-22.04-LTS-HVM
-  LinuxBastionSshPort:
-    Type: Number
-    Description: TCP port to use for the Linux bastion host listening port.
-    MinValue: 0
-    MaxValue: 65535
-    Default: 22
   TanzuNetUsername:
     Type: String
     Description: >-
@@ -531,13 +503,6 @@ Parameters:
       - 'Yes'
       - 'No'
     Default: 'No'
-  SampleAppName:
-    Type: String
-    Description: >-
-      Name of the sample application to deploy into your Amazon EKS cluster.
-    AllowedValues:
-      - tanzu-java-web-app-workload
-    Default: tanzu-java-web-app-workload
   QSS3BucketName:
     Type: String
     Description: >-
@@ -625,8 +590,8 @@ Resources:
           - !Ref AWS::NoValue
         PublicSubnet1Id: !GetAtt VPCStack.Outputs.PublicSubnet1ID
         RemoteAccessCidr: !Ref RemoteAccessCidr
-        LinuxBastionOS: !Ref LinuxBastionOS
-        LinuxBastionSshPort: !Ref LinuxBastionSshPort
+        LinuxBastionOS: Ubuntu-Server-22.04-LTS-HVM
+        LinuxBastionSshPort: 22
         KeyPairName: !Ref KeyPairName
         NumberOfNodes: !Ref NumberOfNodes
         MaxNumberOfNodes: !Ref MaxNumberOfNodes
@@ -639,7 +604,7 @@ Resources:
         TanzuNetPassword: !Ref TanzuNetPassword
         TanzuNetApiToken: !Ref TanzuNetApiToken
         TanzuNetRelocateImages: !Ref TanzuNetRelocateImages
-        SampleAppName: !Ref SampleAppName
+        SampleAppName: tanzu-java-web-app-workload
         QSS3BucketName: !Ref QSS3BucketName
         QSS3BucketRegion: !Ref QSS3BucketRegion
         QSS3KeyPrefix: !Ref QSS3KeyPrefix

--- a/templates/aws-tap-entrypoint-new-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-new-vpc.template.yaml
@@ -602,7 +602,6 @@ Resources:
         TanzuNetPassword: !Ref TanzuNetPassword
         TanzuNetApiToken: !Ref TanzuNetApiToken
         TanzuNetRelocateImages: !Ref TanzuNetRelocateImages
-        SampleAppName: tanzu-java-web-app-workload
         QSS3BucketName: !Ref QSS3BucketName
         QSS3BucketRegion: !Ref QSS3BucketRegion
         QSS3KeyPrefix: !Ref QSS3KeyPrefix


### PR DESCRIPTION
Links to https://jira.eng.vmware.com/browse/TAPPC-190

* Removed parameters bastionOs, ssh port, and sample app name 
* These fields will now not show up in the new vpc form 