### PR TITLE
Fix learning center in multi-cluster deployments

### DIFF
--- a/tap-setup-scripts/src/inputs/tap-values-view.yaml
+++ b/tap-setup-scripts/src/inputs/tap-values-view.yaml
@@ -8,7 +8,6 @@ shared:
 
 learningcenter:
   ingressDomain: #@ "learning-center.view.{}".format(data.values.dns.domain_name)
-  ingressClass: contour
 
 tap_gui:
   ingressEnabled: true


### PR DESCRIPTION
We don't have an ingress class `contour` on EKS/AWS, thus configuring LC with that has it fail.
We can omit this configuration completely, as we do in the single-cluster world.