### PR TITLE
TAPPC 178 - autodetecting regional and shared resources once for all eks clusters

### DIFF
--- a/templates/aws-tap-entrypoint-existing-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-existing-vpc.template.yaml
@@ -731,7 +731,6 @@ Resources:
         ConfigSetName: !Ref AWS::StackName
         NodeVolumeSize: !Ref NodeVolumeSize
         KubernetesVersion: !FindInMap [ Versions, current, EKS ]
-#shared resources for multi cluster
   AutoDetectSharedResources:
     Type: AWS::CloudFormation::Stack
     Properties:

--- a/templates/aws-tap-entrypoint-existing-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-existing-vpc.template.yaml
@@ -731,11 +731,24 @@ Resources:
         ConfigSetName: !Ref AWS::StackName
         NodeVolumeSize: !Ref NodeVolumeSize
         KubernetesVersion: !FindInMap [ Versions, current, EKS ]
+#shared resources for multi cluster
+  AutoDetectSharedResources:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      TemplateURL: !Sub
+        - https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-amazon-eks/templates/workloads/amazon-eks-prerequisites.template.yaml
+        - S3Region: !If [UsingDefaultBucket, !Ref AWS::Region, !Ref QSS3BucketRegion]
+          S3Bucket: !If [UsingDefaultBucket, !Sub '${QSS3BucketName}-${AWS::Region}', !Ref QSS3BucketName]
+      Parameters:
+        QSS3BucketName: !Ref QSS3BucketName
+        QSS3BucketRegion: !Ref QSS3BucketRegion
+        QSS3KeyPrefix: !Sub ${QSS3KeyPrefix}submodules/quickstart-amazon-eks/
   EKSQSStack:
     Type: AWS::CloudFormation::Stack
     Condition: CreateSingleCluster
     DependsOn:
       - EKSAdvancedConfigStack
+      - AutoDetectSharedResources
     Properties:
       TemplateURL: !Sub
         - https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-amazon-eks/templates/amazon-eks-entrypoint-existing-vpc.template.yaml
@@ -766,12 +779,15 @@ Resources:
         EKSClusterName: !Ref EKSClusterName
         ClusterAutoScaler: Enabled
         LoadBalancerController: Enabled
+        PerRegionSharedResources: 'No'
+        PerAccountSharedResources: 'No'
 #eks stacks multi cluster start
   RUNEKSQSStack:
     Type: AWS::CloudFormation::Stack
     Condition: CreateMultiCluster
     DependsOn:
       - EKSAdvancedConfigStack
+      - AutoDetectSharedResources
     Properties:
       TemplateURL: !Sub
         - https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-amazon-eks/templates/amazon-eks-entrypoint-existing-vpc.template.yaml
@@ -802,11 +818,14 @@ Resources:
         EKSClusterName: !Sub ${EKSClusterName}-run
         ClusterAutoScaler: Enabled
         LoadBalancerController: Enabled
+        PerRegionSharedResources: 'No'
+        PerAccountSharedResources: 'No'
   VIEWEKSQSStack:
     Type: AWS::CloudFormation::Stack
     Condition: CreateMultiCluster
     DependsOn:
       - EKSAdvancedConfigStack
+      - AutoDetectSharedResources
     Properties:
       TemplateURL: !Sub
         - https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-amazon-eks/templates/amazon-eks-entrypoint-existing-vpc.template.yaml
@@ -837,11 +856,14 @@ Resources:
         EKSClusterName: !Sub ${EKSClusterName}-view
         ClusterAutoScaler: Enabled
         LoadBalancerController: Enabled
+        PerRegionSharedResources: 'No'
+        PerAccountSharedResources: 'No'
   BUILDEKSQSStack:
     Type: AWS::CloudFormation::Stack
     Condition: CreateMultiCluster
     DependsOn:
       - EKSAdvancedConfigStack
+      - AutoDetectSharedResources
     Properties:
       TemplateURL: !Sub
         - https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-amazon-eks/templates/amazon-eks-entrypoint-existing-vpc.template.yaml
@@ -872,11 +894,14 @@ Resources:
         EKSClusterName: !Sub ${EKSClusterName}-build
         ClusterAutoScaler: Enabled
         LoadBalancerController: Enabled
+        PerRegionSharedResources: 'No'
+        PerAccountSharedResources: 'No'
   ITERATEEKSQSStack:
     Type: AWS::CloudFormation::Stack
     Condition: CreateMultiCluster
     DependsOn:
       - EKSAdvancedConfigStack
+      - AutoDetectSharedResources
     Properties:
       TemplateURL: !Sub
         - https://${S3Bucket}.s3.${S3Region}.${AWS::URLSuffix}/${QSS3KeyPrefix}submodules/quickstart-amazon-eks/templates/amazon-eks-entrypoint-existing-vpc.template.yaml
@@ -907,6 +932,8 @@ Resources:
         EKSClusterName: !Sub ${EKSClusterName}-iterate
         ClusterAutoScaler: Enabled
         LoadBalancerController: Enabled
+        PerRegionSharedResources: 'No'
+        PerAccountSharedResources: 'No'
 #eks stacks for multi cluster end
 #Rules for multi cluster start
   RunLinuxBastionSshToNodesEgressRule:


### PR DESCRIPTION
https://jira.eng.vmware.com/browse/TAPPC-178 

* AutoDetectSharedResources resource has been copied into our existing vpc template 
* All EKS cluster resources depend on our AutoDetectSharedResources resource 
* Disabling AutoDetect for shared resources in EKS resource params to quickstart-aws-eks existing vpc template