### PR TITLE
Validate TAP domain name in the templates

### DIFF
--- a/templates/aws-tap-entrypoint-existing-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-existing-vpc.template.yaml
@@ -137,10 +137,11 @@ Parameters:
       - 'No'
     Default: 'No'
   TAPDomainName:
-   Type: String
-   Description: >-
+    Type: String
+    Description: >-
       Private DNS domain name for accessing the TAP graphical user interface
       (GUI) and project URLs.
+    AllowedPattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$  #! from cnrs
   TAPClusterArch:
     Type: String
     Description: TAP cluster architecture.

--- a/templates/aws-tap-entrypoint-new-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-new-vpc.template.yaml
@@ -149,10 +149,11 @@ Parameters:
       - 'No'
     Default: 'No'
   TAPDomainName:
-   Type: String
-   Description: >-
+    Type: String
+    Description: >-
       Private DNS domain name for accessing the TAP graphical user interface
       (GUI) and project URLs.
+    AllowedPattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$  #! from cnrs
   TAPClusterArch:
     Type: String
     Description: TAP cluster architecture.


### PR DESCRIPTION
For earlier feedback the template checks the user provided domain name with the same RE that is used in CNR.