### PR TITLE
Test image relocation in the pipeline

### DIFF
--- a/.taskcat.yml
+++ b/.taskcat.yml
@@ -18,7 +18,6 @@ project:
     TanzuNetUsername: --override--
     TanzuNetPassword: --override--
     TanzuNetApiToken: --override--
-    TanzuNetRelocateImages: --override--
     TAPDomainName: --override--
     QSS3BucketName: $[taskcat_autobucket]
     QSS3BucketRegion: $[taskcat_current_region]
@@ -30,11 +29,25 @@ tests:
   single-cluster:
     parameters:
       TAPClusterArch: single
+      TanzuNetRelocateImages: "No"
     regions:
       - us-east-1
       - eu-south-1
   multi-cluster:
     parameters:
       TAPClusterArch: multi
+      TanzuNetRelocateImages: "No"
     regions:
       - us-west-2
+  relocation-single:
+    parameters:
+      TAPClusterArch: single
+      TanzuNetRelocateImages: "Yes"
+    regions:
+      - us-west-2
+  relocation-multi:
+    parameters:
+      TAPClusterArch: multi
+      TanzuNetRelocateImages: "Yes"
+    regions:
+      - us-east-1

--- a/ci/qs-test/pipeline.yml
+++ b/ci/qs-test/pipeline.yml
@@ -108,13 +108,27 @@ alerting:
 
 groups:
 - name: main
-  jobs: [ prepare-bucket, test-static, test-single-us-east-1, test-single-eu-south-1, test-multi-us-west-2, publish-bucket, set-pipeline ]
+  jobs:
+  - prepare-bucket
+  - test-static
+  - test-single-us-east-1
+  - test-single-eu-south-1
+  - test-multi-us-west-2
+  - test-relocation-single-us-west-2
+  - test-relocation-multi-us-east-1
+  - publish-bucket
+  - set-pipeline
 - name: pr
-  jobs: [ "pr-*", set-pipeline ]
+  jobs:
+  - "pr-*"
+  - set-pipeline
 - name: housekeeping
-  jobs: [ "housekeeping-*", set-pipeline ]
+  jobs:
+  - "housekeeping-*"
+  - set-pipeline
 - name: all
-  jobs: [ "*" ]
+  jobs:
+  - "*"
 
 jobs:
 - name: set-pipeline
@@ -277,6 +291,58 @@ jobs:
       REGIONS: "us-west-2"
     ensure: *postTest
 
+- name: test-relocation-single-us-west-2
+  << : *alertingOnJobs
+  serial: true
+  plan:
+  - in_parallel:
+    - get: ci-repo
+      params:
+        submodules: none
+      trigger: true
+      passed: [ prepare-bucket ]
+    - get: repo
+      params:
+        submodules: none
+      trigger: true
+      passed: [ prepare-bucket ]
+    - get: daily-run
+      trigger: true
+      passed: [ prepare-bucket ]
+  - *setup
+  - task: taskcat-test
+    file: ci-repo/ci/tasks/taskcat-run-test/task.yml
+    params:
+      TEST_NAME: relocation-single
+      REGIONS: "us-west-2"
+    ensure: *postTest
+
+- name: test-relocation-multi-us-east-1
+  << : *alertingOnJobs
+  serial: true
+  plan:
+  - in_parallel:
+    - get: ci-repo
+      params:
+        submodules: none
+      trigger: true
+      passed: [ prepare-bucket ]
+    - get: repo
+      params:
+        submodules: none
+      trigger: true
+      passed: [ prepare-bucket ]
+    - get: daily-run
+      trigger: true
+      passed: [ prepare-bucket ]
+  - *setup
+  - task: taskcat-test
+    file: ci-repo/ci/tasks/taskcat-run-test/task.yml
+    params:
+      TEST_NAME: relocation-multi
+      REGIONS: "us-east-1"
+    ensure: *postTest
+
 - name: publish-bucket
   << : *alertingOnJobs
   plan:
@@ -285,12 +351,17 @@ jobs:
       params:
         submodules: none
       trigger: true
-      passed: [ test-single-us-east-1, test-single-eu-south-1, test-multi-us-west-2 ]
+      passed: &passedForPublishBucket
+      - test-single-us-east-1
+      - test-single-eu-south-1
+      - test-multi-us-west-2
+      - test-relocation-single-us-west-2
+      - test-relocation-multi-us-east-1
     - get: repo
       params:
         submodules: none
       trigger: true
-      passed: [ test-single-us-east-1, test-single-eu-south-1, test-multi-us-west-2 ]
+      passed: *passedForPublishBucket
   - *setup
   - task: publish-bucket
     file: ci-repo/ci/tasks/taskcat-bucket-sync/task.yml
@@ -420,12 +491,61 @@ jobs:
       REGIONS: "us-west-2"
     ensure: *postTest
 
+- name: pr-test-relocation-single-us-west-2
+  << : *alertginOnPrJobs
+  serial: true
+  plan:
+  - in_parallel:
+    - get: ci-repo
+      params:
+        submodules: none
+      trigger: true
+      passed: [ pr-prepare-bucket ]
+    - get: repo
+      resource: pull-request
+      trigger: true
+      passed: [ pr-prepare-bucket ]
+  - *setup
+  - task: taskcat-test
+    file: ci-repo/ci/tasks/taskcat-run-test/task.yml
+    params:
+      TEST_NAME: relocation-single
+      REGIONS: "us-west-2"
+    ensure: *postTest
+
+- name: pr-test-relocation-multi-us-east-1
+  << : *alertginOnPrJobs
+  serial: true
+  plan:
+  - in_parallel:
+    - get: ci-repo
+      params:
+        submodules: none
+      trigger: true
+      passed: [ pr-prepare-bucket ]
+    - get: repo
+      resource: pull-request
+      trigger: true
+      passed: [ pr-prepare-bucket ]
+  - *setup
+  - task: taskcat-test
+    file: ci-repo/ci/tasks/taskcat-run-test/task.yml
+    params:
+      TEST_NAME: relocation-multi
+      REGIONS: "us-east-1"
+    ensure: *postTest
+
 - name: pr-set-success
   plan:
   - get: repo
     resource: pull-request
     trigger: true
-    passed: [ pr-test-single-us-east-1, pr-test-single-eu-south-1, pr-test-multi-us-west-2 ]
+    passed:
+    - pr-test-single-us-east-1
+    - pr-test-single-eu-south-1
+    - pr-test-multi-us-west-2
+    - pr-test-relocation-single-us-west-2
+    - pr-test-relocation-multi-us-east-1
   - put: pull-request
     params:
       path: repo

--- a/ci/qs-test/pipeline.yml
+++ b/ci/qs-test/pipeline.yml
@@ -29,7 +29,6 @@ resources:
     - ci/qs-test/
     - ci/tasks/
 - name: housekeeping-daily
-  old_name: houekeeping-time
   icon: wrench-clock
   type: time
   source:
@@ -207,7 +206,6 @@ jobs:
 - name: test-single-us-east-1
   << : *alertingOnJobs
   serial: true
-  old_name: test-single
   plan:
   - in_parallel:
     - get: ci-repo
@@ -267,7 +265,6 @@ jobs:
 - name: test-multi-us-west-2
   << : *alertingOnJobs
   serial: true
-  old_name: test-multi
   plan:
   - in_parallel:
     - get: ci-repo
@@ -426,7 +423,6 @@ jobs:
 - name: pr-test-single-us-east-1
   << : *alertginOnPrJobs
   serial: true
-  old_name: pr-test-single
   plan:
   - in_parallel:
     - get: ci-repo
@@ -471,7 +467,6 @@ jobs:
 - name: pr-test-multi-us-west-2
   << : *alertginOnPrJobs
   serial: true
-  old_name: pr-test-multi
   plan:
   - in_parallel:
     - get: ci-repo

--- a/ci/qs-test/taskcat_overlay.yml
+++ b/ci/qs-test/taskcat_overlay.yml
@@ -37,7 +37,6 @@ project:
     TanzuNetUsername: #@ tanzunet_username
     TanzuNetPassword: #@ tanzunet_password
     TanzuNetApiToken: #@ tanzunet_refreshToken
-    TanzuNetRelocateImages: "No"
     TAPDomainName: #@ "{}.{}".format("$[taskcat_random-string]", domain)
     QSS3KeyPrefix: #@ gitSha + "/"
   tags:


### PR DESCRIPTION
- Add separate taskcat tests to test relocation of CE & TAP images.
- Run those tests in concourse as part of the "main" and the "PR" pipeline
- opportunistically does some pipeline cleanup (removal of `old_name` for already renamed jobs)

