### PR TITLE
Removing eksclustername from template parameters and adding to name map

### DIFF
--- a/templates/aws-tap-entrypoint-existing-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-existing-vpc.template.yaml
@@ -484,17 +484,6 @@ Parameters:
      information, refer to https://aws-quickstart.github.io/option1.html.
     Default: us-east-1
 Mappings:
-  EKSClusterNames:
-    Single:
-      Name: cluster-eks-tap
-    Run:
-      Name: cluster-eks-tap-run
-    View:
-      Name: cluster-eks-tap-view
-    Iterate:
-      Name: cluster-eks-tap-iterate
-    Build:
-      Name: cluster-eks-tap-build
   Versions:
     current:
       TAP: 1.4.2
@@ -803,7 +792,7 @@ Resources:
         NodeInstanceFamily: Standard
         NodeGroupType: Managed
         NodeGroupOS: Amazon Linux 2
-        EKSClusterName: !Join ['-', [!FindInMap [ EKSClusterNames, Single, Name ], !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
+        EKSClusterName: !Join ['-', ['tap', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
         ClusterAutoScaler: Enabled
         LoadBalancerController: Enabled
         PerRegionSharedResources: 'No'
@@ -842,7 +831,7 @@ Resources:
         NodeInstanceFamily: Standard
         NodeGroupType: Managed
         NodeGroupOS: Amazon Linux 2
-        EKSClusterName: !Join ['-', [!FindInMap [ EKSClusterNames, Run, Name ], !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
+        EKSClusterName: !Join ['-', ['tap-run', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
         ClusterAutoScaler: Enabled
         LoadBalancerController: Enabled
         PerRegionSharedResources: 'No'
@@ -880,7 +869,7 @@ Resources:
         NodeInstanceFamily: Standard
         NodeGroupType: Managed
         NodeGroupOS: Amazon Linux 2
-        EKSClusterName: !Join ['-', [!FindInMap [ EKSClusterNames, View, Name ], !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
+        EKSClusterName: !Join ['-', ['tap-view', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
         ClusterAutoScaler: Enabled
         LoadBalancerController: Enabled
         PerRegionSharedResources: 'No'
@@ -918,7 +907,7 @@ Resources:
         NodeInstanceFamily: Standard
         NodeGroupType: Managed
         NodeGroupOS: Amazon Linux 2
-        EKSClusterName: !Join ['-', [!FindInMap [ EKSClusterNames, Build, Name ], !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
+        EKSClusterName: !Join ['-', ['tap-build', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
         ClusterAutoScaler: Enabled
         LoadBalancerController: Enabled
         PerRegionSharedResources: 'No'
@@ -956,7 +945,7 @@ Resources:
         NodeInstanceFamily: Standard
         NodeGroupType: Managed
         NodeGroupOS: Amazon Linux 2
-        EKSClusterName: !Join ['-', [!FindInMap [ EKSClusterNames, Iterate, Name ], !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
+        EKSClusterName: !Join ['-', ['tap-iterate', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
         ClusterAutoScaler: Enabled
         LoadBalancerController: Enabled
         PerRegionSharedResources: 'No'
@@ -1374,19 +1363,19 @@ Resources:
                 Resource:
                   - !Sub
                       - arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${EKSClusterNameSingle}
-                      - EKSClusterNameSingle: !Join ['-', [!FindInMap [ EKSClusterNames, Single, Name ], !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
+                      - EKSClusterNameSingle: !Join ['-', ['tap', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
                   - !Sub
                       - arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${EKSClusterNameRun}
-                      - EKSClusterNameRun: !Join ['-', [!FindInMap [ EKSClusterNames, Run, Name ], !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
+                      - EKSClusterNameRun: !Join ['-', ['tap-run', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
                   - !Sub
                       - arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${EKSClusterNameBuild}
-                      - EKSClusterNameBuild: !Join ['-', [!FindInMap [ EKSClusterNames, Build, Name ], !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
+                      - EKSClusterNameBuild: !Join ['-', ['tap-build', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
                   - !Sub
                       - arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${EKSClusterNameIterate}
-                      - EKSClusterNameIterate: !Join ['-', [!FindInMap [ EKSClusterNames, Iterate, Name ], !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
+                      - EKSClusterNameIterate: !Join ['-', ['tap-iterate', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
                   - !Sub
                       - arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${EKSClusterNameView}
-                      - EKSClusterNameView: !Join ['-', [!FindInMap [ EKSClusterNames, View, Name ], !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
+                      - EKSClusterNameView: !Join ['-', ['tap-view', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
               - Sid: DescribeEksAddons
                 Effect: Allow
                 Action:
@@ -2274,7 +2263,7 @@ Resources:
               IterateClusterWorkloadArn: !If [CreateMultiCluster, !GetAtt ITERATEWorkloadIamRole.Arn, ""]
               RunClusterName: !If [CreateMultiCluster, !GetAtt RUNEKSQSStack.Outputs.EKSClusterName, ""]
               ViewClusterName: !If [CreateMultiCluster, !GetAtt VIEWEKSQSStack.Outputs.EKSClusterName, ""]
-              EKSClusterName: !Join ['-', [!FindInMap [ EKSClusterNames, Single, Name ], !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
+              EKSClusterName: !If [CreateSingleCluster, !GetAtt EKSQSStack.Outputs.EKSClusterName, ""]
               CloudInitHandle:          !Ref PhaseCloudInitHandle
               TAPInstallHandle:         !Ref PhaseTAPInstallHandle
               TAPWorkloadInstallHandle: !Ref PhaseTAPWorkloadInstallHandle

--- a/templates/aws-tap-entrypoint-existing-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-existing-vpc.template.yaml
@@ -2274,7 +2274,7 @@ Resources:
               IterateClusterWorkloadArn: !If [CreateMultiCluster, !GetAtt ITERATEWorkloadIamRole.Arn, ""]
               RunClusterName: !If [CreateMultiCluster, !GetAtt RUNEKSQSStack.Outputs.EKSClusterName, ""]
               ViewClusterName: !If [CreateMultiCluster, !GetAtt VIEWEKSQSStack.Outputs.EKSClusterName, ""]
-
+              EKSClusterName: !FindInMap [EKSClusterNames, Single, Name]
               CloudInitHandle:          !Ref PhaseCloudInitHandle
               TAPInstallHandle:         !Ref PhaseTAPInstallHandle
               TAPWorkloadInstallHandle: !Ref PhaseTAPWorkloadInstallHandle

--- a/templates/aws-tap-entrypoint-existing-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-existing-vpc.template.yaml
@@ -52,7 +52,6 @@ Metadata:
       - Label:
           default: Amazon EKS configuration
         Parameters:
-          - EKSClusterName
           - NodeInstanceType
           - NodeVolumeSize
           - NumberOfNodes
@@ -86,8 +85,6 @@ Metadata:
         default: Domain name
       TAPClusterArch:
         default: EKS single or multi cluster
-      EKSClusterName:
-        default: EKS cluster name
       NodeInstanceType:
         default: Instance type
       NodeVolumeSize:
@@ -185,16 +182,6 @@ Parameters:
       are supported due to Windows instances not supporting ED25519. For more
       information, refer to Amazon EC2 key pairs and Windows instances
       (https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/ec2-key-pairs.html).
-  EKSClusterName:
-    Type: String
-    Description: Name of the EKS cluster where TAP will be deployed.
-    MinLength: 1
-    MaxLength: 100
-    AllowedPattern: ^[0-9A-Za-z][A-Za-z0-9\-_]*
-    ConstraintDescription: >-
-      Minimum length of 1. Maximum length of 100. Must start with a letter or
-      number.
-    Default: cluster-eks-tap
   NumberOfNodes:
     Type: Number
     Description: Minimum number of nodes to create for the TAP EKS cluster.
@@ -497,6 +484,17 @@ Parameters:
      information, refer to https://aws-quickstart.github.io/option1.html.
     Default: us-east-1
 Mappings:
+  EKSClusterNames:
+    Single:
+      Name: cluster-eks-tap
+    Run:
+      Name: cluster-eks-tap-run
+    View:
+      Name: cluster-eks-tap-view
+    Iterate:
+      Name: cluster-eks-tap-iterate
+    Build:
+      Name: cluster-eks-tap-build
   Versions:
     current:
       TAP: 1.4.2
@@ -805,7 +803,7 @@ Resources:
         NodeInstanceFamily: Standard
         NodeGroupType: Managed
         NodeGroupOS: Amazon Linux 2
-        EKSClusterName: !Ref EKSClusterName
+        EKSClusterName: !FindInMap [ EKSClusterNames, Single, Name ]
         ClusterAutoScaler: Enabled
         LoadBalancerController: Enabled
         PerRegionSharedResources: 'No'
@@ -844,7 +842,7 @@ Resources:
         NodeInstanceFamily: Standard
         NodeGroupType: Managed
         NodeGroupOS: Amazon Linux 2
-        EKSClusterName: !Sub ${EKSClusterName}-run
+        EKSClusterName: !FindInMap [ EKSClusterNames, Run, Name ]
         ClusterAutoScaler: Enabled
         LoadBalancerController: Enabled
         PerRegionSharedResources: 'No'
@@ -882,7 +880,7 @@ Resources:
         NodeInstanceFamily: Standard
         NodeGroupType: Managed
         NodeGroupOS: Amazon Linux 2
-        EKSClusterName: !Sub ${EKSClusterName}-view
+        EKSClusterName: !FindInMap [ EKSClusterNames, View, Name ]
         ClusterAutoScaler: Enabled
         LoadBalancerController: Enabled
         PerRegionSharedResources: 'No'
@@ -920,7 +918,7 @@ Resources:
         NodeInstanceFamily: Standard
         NodeGroupType: Managed
         NodeGroupOS: Amazon Linux 2
-        EKSClusterName: !Sub ${EKSClusterName}-build
+        EKSClusterName: !FindInMap [ EKSClusterNames, Build, Name ]
         ClusterAutoScaler: Enabled
         LoadBalancerController: Enabled
         PerRegionSharedResources: 'No'
@@ -958,7 +956,7 @@ Resources:
         NodeInstanceFamily: Standard
         NodeGroupType: Managed
         NodeGroupOS: Amazon Linux 2
-        EKSClusterName: !Sub ${EKSClusterName}-iterate
+        EKSClusterName: !FindInMap [ EKSClusterNames, Iterate, Name ]
         ClusterAutoScaler: Enabled
         LoadBalancerController: Enabled
         PerRegionSharedResources: 'No'
@@ -1374,11 +1372,21 @@ Resources:
                   - eks:DescribeCluster
                   - eks:DescribeNodegroup
                 Resource:
-                  - !Sub arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${EKSClusterName}
-                  - !Sub arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${EKSClusterName}-run
-                  - !Sub arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${EKSClusterName}-build
-                  - !Sub arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${EKSClusterName}-iterate
-                  - !Sub arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${EKSClusterName}-view
+                  - !Sub
+                      - arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${EKSClusterNameSingle}
+                      - EKSClusterNameSingle: !FindInMap [ EKSClusterNames, Single, Name ]
+                  - !Sub
+                      - arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${EKSClusterNameRun}
+                      - EKSClusterNameRun: !FindInMap [ EKSClusterNames, Run, Name ]
+                  - !Sub
+                      - arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${EKSClusterNameBuild}
+                      - EKSClusterNameBuild: !FindInMap [ EKSClusterNames, Build, Name ]
+                  - !Sub
+                      - arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${EKSClusterNameIterate}
+                      - EKSClusterNameIterate: !FindInMap [ EKSClusterNames, Iterate, Name ]
+                  - !Sub
+                      - arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${EKSClusterNameView}
+                      - EKSClusterNameView: !FindInMap [ EKSClusterNames, View, Name ]
               - Sid: DescribeEksAddons
                 Effect: Allow
                 Action:

--- a/templates/aws-tap-entrypoint-existing-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-existing-vpc.template.yaml
@@ -486,15 +486,15 @@ Parameters:
 Mappings:
   EKSClusterNames:
     Single:
-      Name: !Join ['-', ['cluster-eks-tap', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
+      Name: cluster-eks-tap
     Run:
-      Name: !Join ['-', ['cluster-eks-tap-run', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
+      Name: cluster-eks-tap-run
     View:
-      Name: !Join ['-', ['cluster-eks-tap-view', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
+      Name: cluster-eks-tap-view
     Iterate:
-      Name: !Join ['-', ['cluster-eks-tap-iterate', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
+      Name: cluster-eks-tap-iterate
     Build:
-      Name: !Join ['-', ['cluster-eks-tap-build', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
+      Name: cluster-eks-tap-build
   Versions:
     current:
       TAP: 1.4.2
@@ -803,7 +803,7 @@ Resources:
         NodeInstanceFamily: Standard
         NodeGroupType: Managed
         NodeGroupOS: Amazon Linux 2
-        EKSClusterName: !FindInMap [ EKSClusterNames, Single, Name ]
+        EKSClusterName: !Join ['-', [!FindInMap [ EKSClusterNames, Single, Name ], !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
         ClusterAutoScaler: Enabled
         LoadBalancerController: Enabled
         PerRegionSharedResources: 'No'
@@ -842,7 +842,7 @@ Resources:
         NodeInstanceFamily: Standard
         NodeGroupType: Managed
         NodeGroupOS: Amazon Linux 2
-        EKSClusterName: !FindInMap [ EKSClusterNames, Run, Name ]
+        EKSClusterName: !Join ['-', [!FindInMap [ EKSClusterNames, Run, Name ], !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
         ClusterAutoScaler: Enabled
         LoadBalancerController: Enabled
         PerRegionSharedResources: 'No'
@@ -880,7 +880,7 @@ Resources:
         NodeInstanceFamily: Standard
         NodeGroupType: Managed
         NodeGroupOS: Amazon Linux 2
-        EKSClusterName: !FindInMap [ EKSClusterNames, View, Name ]
+        EKSClusterName: !Join ['-', [!FindInMap [ EKSClusterNames, View, Name ], !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
         ClusterAutoScaler: Enabled
         LoadBalancerController: Enabled
         PerRegionSharedResources: 'No'
@@ -918,7 +918,7 @@ Resources:
         NodeInstanceFamily: Standard
         NodeGroupType: Managed
         NodeGroupOS: Amazon Linux 2
-        EKSClusterName: !FindInMap [ EKSClusterNames, Build, Name ]
+        EKSClusterName: !Join ['-', [!FindInMap [ EKSClusterNames, Build, Name ], !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
         ClusterAutoScaler: Enabled
         LoadBalancerController: Enabled
         PerRegionSharedResources: 'No'
@@ -956,7 +956,7 @@ Resources:
         NodeInstanceFamily: Standard
         NodeGroupType: Managed
         NodeGroupOS: Amazon Linux 2
-        EKSClusterName: !FindInMap [ EKSClusterNames, Iterate, Name ]
+        EKSClusterName: !Join ['-', [!FindInMap [ EKSClusterNames, Iterate, Name ], !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
         ClusterAutoScaler: Enabled
         LoadBalancerController: Enabled
         PerRegionSharedResources: 'No'
@@ -1374,19 +1374,19 @@ Resources:
                 Resource:
                   - !Sub
                       - arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${EKSClusterNameSingle}
-                      - EKSClusterNameSingle: !FindInMap [ EKSClusterNames, Single, Name ]
+                      - EKSClusterNameSingle: !Join ['-', [!FindInMap [ EKSClusterNames, Single, Name ], !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
                   - !Sub
                       - arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${EKSClusterNameRun}
-                      - EKSClusterNameRun: !FindInMap [ EKSClusterNames, Run, Name ]
+                      - EKSClusterNameRun: !Join ['-', [!FindInMap [ EKSClusterNames, Run, Name ], !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
                   - !Sub
                       - arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${EKSClusterNameBuild}
-                      - EKSClusterNameBuild: !FindInMap [ EKSClusterNames, Build, Name ]
+                      - EKSClusterNameBuild: !Join ['-', [!FindInMap [ EKSClusterNames, Build, Name ], !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
                   - !Sub
                       - arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${EKSClusterNameIterate}
-                      - EKSClusterNameIterate: !FindInMap [ EKSClusterNames, Iterate, Name ]
+                      - EKSClusterNameIterate: !Join ['-', [!FindInMap [ EKSClusterNames, Iterate, Name ], !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
                   - !Sub
                       - arn:${AWS::Partition}:eks:${AWS::Region}:${AWS::AccountId}:cluster/${EKSClusterNameView}
-                      - EKSClusterNameView: !FindInMap [ EKSClusterNames, View, Name ]
+                      - EKSClusterNameView: !Join ['-', [!FindInMap [ EKSClusterNames, View, Name ], !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
               - Sid: DescribeEksAddons
                 Effect: Allow
                 Action:
@@ -2274,7 +2274,7 @@ Resources:
               IterateClusterWorkloadArn: !If [CreateMultiCluster, !GetAtt ITERATEWorkloadIamRole.Arn, ""]
               RunClusterName: !If [CreateMultiCluster, !GetAtt RUNEKSQSStack.Outputs.EKSClusterName, ""]
               ViewClusterName: !If [CreateMultiCluster, !GetAtt VIEWEKSQSStack.Outputs.EKSClusterName, ""]
-              EKSClusterName: !FindInMap [EKSClusterNames, Single, Name]
+              EKSClusterName: !Join ['-', [!FindInMap [ EKSClusterNames, Single, Name ], !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
               CloudInitHandle:          !Ref PhaseCloudInitHandle
               TAPInstallHandle:         !Ref PhaseTAPInstallHandle
               TAPWorkloadInstallHandle: !Ref PhaseTAPWorkloadInstallHandle

--- a/templates/aws-tap-entrypoint-existing-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-existing-vpc.template.yaml
@@ -486,15 +486,15 @@ Parameters:
 Mappings:
   EKSClusterNames:
     Single:
-      Name: cluster-eks-tap
+      Name: !Join ['-', ['cluster-eks-tap', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
     Run:
-      Name: cluster-eks-tap-run
+      Name: !Join ['-', ['cluster-eks-tap-run', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
     View:
-      Name: cluster-eks-tap-view
+      Name: !Join ['-', ['cluster-eks-tap-view', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
     Iterate:
-      Name: cluster-eks-tap-iterate
+      Name: !Join ['-', ['cluster-eks-tap-iterate', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
     Build:
-      Name: cluster-eks-tap-build
+      Name: !Join ['-', ['cluster-eks-tap-build', !Select [4, !Split ['-', !Select [2, !Split ['/', !Ref AWS::StackId]]]]]]
   Versions:
     current:
       TAP: 1.4.2

--- a/templates/aws-tap-entrypoint-new-vpc.template.yaml
+++ b/templates/aws-tap-entrypoint-new-vpc.template.yaml
@@ -56,7 +56,6 @@ Metadata:
       - Label:
           default: Amazon EKS configuration
         Parameters:
-          - EKSClusterName
           - NodeInstanceType
           - NodeVolumeSize
           - NumberOfNodes
@@ -98,8 +97,6 @@ Metadata:
         default: Domain name
       TAPClusterArch:
         default: EKS single or multi cluster
-      EKSClusterName:
-        default: EKS cluster name
       NodeInstanceType:
         default: Instance type
       NodeVolumeSize:
@@ -234,17 +231,6 @@ Parameters:
       are supported due to Windows instances not supporting ED25519. For more
       information, refer to Amazon EC2 key pairs and Windows instances
       (https://docs.aws.amazon.com/AWSEC2/latest/WindowsGuide/ec2-key-pairs.html).
-  EKSClusterName:
-    Type: String
-    Description: >-
-      Name of the EKS cluster where TAP will be deployed.
-    MinLength: 1
-    MaxLength: 100
-    AllowedPattern: ^[0-9A-Za-z][A-Za-z0-9\-_]*
-    ConstraintDescription: >-
-      Minimum length of 1. Maximum length of 100. Must start with a letter or
-      number.
-    Default: cluster-eks-tap
   NumberOfNodes:
     Type: Number
     Description: Minimum number of nodes to create for the TAP EKS cluster.
@@ -596,7 +582,6 @@ Resources:
         MaxNumberOfNodes: !Ref MaxNumberOfNodes
         NodeInstanceType: !Ref NodeInstanceType
         NodeVolumeSize: !Ref NodeVolumeSize
-        EKSClusterName: !Ref EKSClusterName
         TAPDomainName: !Ref TAPDomainName
         TAPClusterArch: !Ref TAPClusterArch
         TanzuNetUsername: !Ref TanzuNetUsername


### PR DESCRIPTION
https://jira.eng.vmware.com/browse/TAPPC-177 
* Removing EksClusterName parameter from new vpc template / form 
* Using stack id string appended to eks cluster names to ensure uniqueness between deploys
* Creating map of EksClusterNames for different clusters instead of hardcoding for multicluster 
* Utilizing map lookups instead of !refs to parameter 
