### PR TITLE
DON'T MERGE - Use the EKS stack fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "submodules/quickstart-amazon-eks"]
 	path = submodules/quickstart-amazon-eks
-	url = https://github.com/aws-quickstart/quickstart-amazon-eks.git
-	branch = main
+	url = https://github.com/hoegaarden/quickstart-amazon-eks.git
+	branch = tmp-rollback


### PR DESCRIPTION
- roll back to a version which worked for us
- blow away the rancher submodule